### PR TITLE
swap lucide-svelte for @lucide/svelte v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "zwfm-knabbel",
       "version": "0.0.1",
       "dependencies": {
+        "@lucide/svelte": "^1.7.0",
         "daisyui": "^5.5.19",
-        "lucide-svelte": "^0.562.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -824,6 +824,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lucide/svelte": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.7.0.tgz",
+      "integrity": "sha512-YytBKOUBGox7yWcykZnYxOkn5WpR5G1qYXLYXV/j1B79SOTTEKzB+s5yF5Rq9l9OkweDStNH2b4yTqfvhEhV8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "svelte": "^5"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3200,15 +3209,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lucide-svelte": {
-      "version": "0.562.0",
-      "resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-0.562.0.tgz",
-      "integrity": "sha512-kSJDH/55lf0mun/o4nqWBXOcq0fWYzPeIjbTD97ywoeumAB9kWxtM06gC7oynqjtK3XhAljWSz5RafIzPEYIQA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "svelte": "^3 || ^4 || ^5.0.0-next.42"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "vite": "^7.2.6"
   },
   "dependencies": {
+    "@lucide/svelte": "^1.7.0",
     "daisyui": "^5.5.19",
-    "lucide-svelte": "^0.562.0",
     "zod": "^3.25.76"
   }
 }

--- a/src/lib/components/ReadMode.svelte
+++ b/src/lib/components/ReadMode.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { X, AlertTriangle } from './icons'
+  import { X, TriangleAlert } from './icons'
   import { formatDuration } from '$lib/utils/format'
 
   interface Props {
@@ -158,7 +158,7 @@
   {:else}
     <!-- Empty state -->
     <div class="flex flex-1 flex-col items-center justify-center gap-4 text-white/40">
-      <AlertTriangle
+      <TriangleAlert
         aria-hidden="true"
         class="size-12 text-primary opacity-60"
       />

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { toast } from '$lib/stores/toast'
-  import { CheckCircle, AlertCircle, AlertTriangle, Info, X } from './icons'
+  import { CircleCheckBig, CircleAlert, TriangleAlert, Info, X } from './icons'
 
   const iconMap = {
-    success: CheckCircle,
-    error: AlertCircle,
-    warning: AlertTriangle,
+    success: CircleCheckBig,
+    error: CircleAlert,
+    warning: TriangleAlert,
     info: Info,
   }
 

--- a/src/lib/components/icons.ts
+++ b/src/lib/components/icons.ts
@@ -1,12 +1,12 @@
 export {
-  AlertCircle,
-  AlertTriangle,
+  CircleAlert,
+  TriangleAlert,
   Zap,
   ArchiveX,
   AudioWaveform,
   CassetteTape,
   Check,
-  CheckCircle,
+  CircleCheckBig,
   ChevronLeft,
   ChevronRight,
   Download,
@@ -32,4 +32,4 @@ export {
   User,
   Users,
   X,
-} from 'lucide-svelte'
+} from '@lucide/svelte'

--- a/src/lib/components/ui/EmptyState.svelte
+++ b/src/lib/components/ui/EmptyState.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-  import type { ComponentType, SvelteComponent } from 'svelte'
+  import type { Component } from 'svelte'
 
   interface Props {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    icon: ComponentType<SvelteComponent<any>>
+    icon: Component
     title: string
     description?: string
     action?: { href: string; label: string }

--- a/src/lib/components/ui/ListPage.svelte
+++ b/src/lib/components/ui/ListPage.svelte
@@ -6,14 +6,13 @@
   import { Plus, Pencil, Trash2 } from '$lib/components/icons'
   import { PageHeader, EmptyState, Pagination } from '$lib/components/ui'
   import type { PaginationInfo } from '$lib/utils/pagination'
-  import type { ComponentType, SvelteComponent, Snippet } from 'svelte'
+  import type { Component, Snippet } from 'svelte'
 
   interface Props {
     title: string
     subtitle: string
     items: T[]
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    icon: ComponentType<SvelteComponent<any>>
+    icon: Component
     newHref?: string
     newLabel?: string
     editHref?: (item: T) => string


### PR DESCRIPTION
## Summary
- Replaces `lucide-svelte` (dead after v1.0.1) with `@lucide/svelte` (Svelte 5 only, actively maintained)
- Renames 3 deprecated icon aliases: `AlertCircle` → `CircleAlert`, `AlertTriangle` → `TriangleAlert`, `CheckCircle` → `CircleCheckBig`
- Updates `EmptyState` and `ListPage` icon prop types from `ComponentType<SvelteComponent>` to `Component` (Svelte 5 style)

## Test plan
- [ ] Verify all icons render correctly on every page
- [ ] Check toast notifications (success/error/warning icons)
- [ ] Check read mode (warning icon for empty state)