### PR TITLE
deps: bump @types/node from 25.9.0 to 25.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2332,9 +2332,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
-      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Cherry-picks the `@types/node` patch bump from #20, leaving the TypeScript 6 upgrade out (still blocked upstream on `openapi-ts/openapi-typescript#2711`).

## Bump
- `@types/node` 25.9.0 → 25.9.1 (lockfile only; `package.json` already allows `^25`)

## Skipped from #20
- `typescript` 5.9.3 → 6.0.3 — blocked: `openapi-typescript@7.13.0` still pins peer dep to `^5.x`

## Test plan
- [x] `npm install` clean
- [x] `npm run lint`
- [x] `npm run build` (with `PUBLIC_API_URL` set)