### PR TITLE
feat: add AI TTS settings page

### DIFF
--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -1,0 +1,9 @@
+import { api, type FetchFn } from './client'
+import type { TTSSettings, TTSSettingsUpdate } from '$lib/types'
+
+export const settingsApi = {
+  getTts: (customFetch?: FetchFn) => api.get<TTSSettings>('/settings/tts', undefined, customFetch),
+
+  updateTts: (data: TTSSettingsUpdate, customFetch?: FetchFn) =>
+    api.patch<TTSSettings>('/settings/tts', data, customFetch),
+}

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -35,7 +35,7 @@
 
   const adminNavItems: NavItem[] = [
     { path: '/users', label: 'Gebruikers', icon: Users },
-    { path: '#', label: 'AI-instellingen', icon: Sparkles },
+    { path: '/settings/ai', label: 'AI-instellingen', icon: Sparkles },
   ]
 
   function isActive(path: string): boolean {

--- a/src/lib/components/ui/SelectInput.svelte
+++ b/src/lib/components/ui/SelectInput.svelte
@@ -19,7 +19,7 @@
     label: string
     /** Value is always a string (HTML select behavior). Use toStringOrEmpty/toNumberOrNull for conversion. */
     value: string | null | undefined
-    options: Option[]
+    options: readonly Option[]
     error?: string
     /**
      * Disabled placeholder option shown when no value is selected.

--- a/src/lib/schemas/tts-settings.ts
+++ b/src/lib/schemas/tts-settings.ts
@@ -1,0 +1,72 @@
+import type { TTSSettings, TTSSettingsUpdate } from '$lib/types'
+import { z } from 'zod'
+
+const ttsModelValues = ['eleven_v3', 'eleven_multilingual_v2', 'eleven_flash_v2_5'] as const
+const textNormalizationValues = ['auto', 'on', 'off'] as const
+
+export const ttsModelOptions = [
+  { value: ttsModelValues[0], label: 'Eleven v3' },
+  { value: ttsModelValues[1], label: 'Eleven Multilingual v2' },
+  { value: ttsModelValues[2], label: 'Eleven Flash v2.5' },
+] satisfies readonly { value: (typeof ttsModelValues)[number]; label: string }[]
+
+export const textNormalizationOptions = [
+  { value: textNormalizationValues[0], label: 'Auto' },
+  { value: textNormalizationValues[1], label: 'Aan' },
+  { value: textNormalizationValues[2], label: 'Uit' },
+] satisfies readonly { value: (typeof textNormalizationValues)[number]; label: string }[]
+
+const uint32Max = 4294967295
+
+const seedSchema = z
+  .string()
+  .trim()
+  .refine(value => value === '' || /^\d+$/.test(value), 'Seed moet een geheel getal zijn')
+  .refine(
+    value => value === '' || Number(value) <= uint32Max,
+    `Seed mag maximaal ${uint32Max} zijn`
+  )
+
+export const ttsSettingsSchema = z.object({
+  model: z.enum(ttsModelValues, { error: 'Model is verplicht' }),
+  stability: z.number().min(0, 'Minimaal 0').max(1, 'Maximaal 1'),
+  similarity_boost: z.number().min(0, 'Minimaal 0').max(1, 'Maximaal 1'),
+  style: z.number().min(0, 'Minimaal 0').max(1, 'Maximaal 1'),
+  use_speaker_boost: z.boolean(),
+  speed: z.number().min(0.7, 'Minimaal 0.7').max(1.2, 'Maximaal 1.2'),
+  apply_text_normalization: z.enum(textNormalizationValues, {
+    error: 'Tekstnormalisatie is verplicht',
+  }),
+  seed: seedSchema,
+  tts_style_prefix: z.string().max(500, 'Maximaal 500 tekens'),
+})
+
+export type TTSSettingsFormData = z.infer<typeof ttsSettingsSchema>
+
+export function toTTSSettingsFormData(settings: TTSSettings): TTSSettingsFormData {
+  return {
+    model: settings.model,
+    stability: settings.stability,
+    similarity_boost: settings.similarity_boost,
+    style: settings.style,
+    use_speaker_boost: settings.use_speaker_boost,
+    speed: settings.speed,
+    apply_text_normalization: settings.apply_text_normalization,
+    seed: settings.seed == null ? '' : String(settings.seed),
+    tts_style_prefix: settings.tts_style_prefix,
+  }
+}
+
+export function toTTSSettingsUpdate(form: TTSSettingsFormData): TTSSettingsUpdate {
+  return {
+    model: form.model,
+    stability: form.stability,
+    similarity_boost: form.similarity_boost,
+    style: form.style,
+    use_speaker_boost: form.use_speaker_boost,
+    speed: form.speed,
+    apply_text_normalization: form.apply_text_normalization,
+    seed: form.seed === '' ? null : Number(form.seed),
+    tts_style_prefix: form.tts_style_prefix,
+  }
+}

--- a/src/lib/schemas/tts-settings.ts
+++ b/src/lib/schemas/tts-settings.ts
@@ -16,6 +16,7 @@ export const textNormalizationOptions = [
   { value: textNormalizationValues[2], label: 'Uit' },
 ] satisfies readonly { value: (typeof textNormalizationValues)[number]; label: string }[]
 
+// ElevenLabs seed range: 0..2^32-1.
 const uint32Max = 4294967295
 
 const seedSchema = z

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -389,10 +389,18 @@ export interface paths {
      * Generate story audio via text-to-speech
      * @description Generates audio for a story using the ElevenLabs text-to-speech API.
      *     Requires the story to have text content and a voice with an ElevenLabs voice ID configured.
-     *     The generated audio replaces any existing audio file for the story.
+     *     The generated audio is stored as the story audio. If the story already has audio,
+     *     the request fails unless `force=true` is provided, in which case the existing
+     *     story audio is replaced.
+     *
+     *     TTS request options are read from the global settings row exposed at
+     *     `GET/PATCH /api/v1/settings/tts`. The API key and timeout remain environment
+     *     configuration; model, voice settings, text normalization, seed, and the
+     *     Eleven v3 style prefix are database-backed settings.
      *
      *     **Prerequisites:**
      *     - TTS must be enabled (BABBEL_ELEVENLABS_API_KEY configured)
+     *     - The `tts_settings` singleton row must exist
      *     - Story must have non-empty `text`
      *     - Story must have a `voice_id` assigned
      *     - The assigned voice must have an `elevenlabs_voice_id` configured
@@ -404,6 +412,39 @@ export interface paths {
     options?: never
     head?: never
     patch?: never
+    trace?: never
+  }
+  '/api/v1/settings/tts': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get global TTS settings
+     * @description Returns the singleton ElevenLabs text-to-speech settings row.
+     *     The response includes whether an API key is configured, but never returns the key value.
+     *     All authenticated roles can read these settings.
+     */
+    get: operations['getSettingsTts']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    /**
+     * Update global TTS settings
+     * @description Partially updates the singleton ElevenLabs text-to-speech settings row.
+     *     Writes are admin-only because these settings affect all subsequent TTS generation.
+     *
+     *     Concurrency: this endpoint uses last-writer-wins semantics. There is no
+     *     optimistic concurrency control (no ETag / If-Match header). If two
+     *     admins PATCH simultaneously, the later request silently overwrites the
+     *     earlier one. Coordinate edits out-of-band when multiple admins manage
+     *     these settings.
+     */
+    patch: operations['patchSettingsTts']
     trace?: never
   }
   '/api/v1/stories/{id}': {
@@ -901,6 +942,53 @@ export interface components {
       created_at?: string
       /** Format: date-time */
       updated_at?: string
+    }
+    /** @description Global singleton ElevenLabs text-to-speech settings. */
+    TTSSettings: {
+      /**
+       * @description ElevenLabs model ID used for subsequent story TTS generation.
+       * @enum {string}
+       */
+      model: 'eleven_v3' | 'eleven_multilingual_v2' | 'eleven_flash_v2_5'
+      /** Format: float */
+      stability: number
+      /** Format: float */
+      similarity_boost: number
+      /** Format: float */
+      style: number
+      /** @description Preserved in settings, but omitted from Eleven v3 request bodies. */
+      use_speaker_boost: boolean
+      /** Format: float */
+      speed: number
+      /** @enum {string} */
+      apply_text_normalization: 'auto' | 'on' | 'off'
+      /** @description Best-effort deterministic seed. Null means random output. */
+      seed: number | null
+      /** @description Audio-tag prefix applied only when model is eleven_v3. */
+      tts_style_prefix: string
+      /** Format: date-time */
+      updated_at: string
+      /** @description Whether BABBEL_ELEVENLABS_API_KEY is configured. */
+      api_key_configured: boolean
+    }
+    /** @description Partial update for global singleton TTS settings. */
+    TTSSettingsUpdate: {
+      /** @enum {string} */
+      model?: 'eleven_v3' | 'eleven_multilingual_v2' | 'eleven_flash_v2_5'
+      /** Format: float */
+      stability?: number
+      /** Format: float */
+      similarity_boost?: number
+      /** Format: float */
+      style?: number
+      use_speaker_boost?: boolean
+      /** Format: float */
+      speed?: number
+      /** @enum {string} */
+      apply_text_normalization?: 'auto' | 'on' | 'off'
+      /** @description Set to null to clear the stored seed. */
+      seed?: number | null
+      tts_style_prefix?: string
     }
     /** @description Represents the relationship between a station and voice with station-specific jingle configuration */
     StationVoice: {
@@ -1486,6 +1574,57 @@ export interface components {
     }
     /** @description Request body too large */
     PayloadTooLarge: {
+      headers: {
+        [name: string]: unknown
+      }
+      content: {
+        'application/problem+json': components['schemas']['ProblemDetails']
+      }
+    }
+    /** @description Request was rate limited */
+    TooManyRequests: {
+      headers: {
+        /** @description Number of seconds to wait before retrying, when provided by the upstream service */
+        'Retry-After'?: string
+        [name: string]: unknown
+      }
+      content: {
+        /**
+         * @example {
+         *       "type": "https://babbel.api/problems/tts.rate_limited",
+         *       "title": "Too Many Requests",
+         *       "status": 429,
+         *       "detail": "TTS rate limited",
+         *       "instance": "/api/v1/stories/1/tts",
+         *       "code": "tts.rate_limited",
+         *       "hint": "Retry the request later"
+         *     }
+         */
+        'application/problem+json': components['schemas']['ProblemDetails']
+      }
+    }
+    /** @description Upstream service failed */
+    BadGateway: {
+      headers: {
+        [name: string]: unknown
+      }
+      content: {
+        /**
+         * @example {
+         *       "type": "https://babbel.api/problems/tts.upstream_failed",
+         *       "title": "Bad Gateway",
+         *       "status": 502,
+         *       "detail": "TTS upstream ElevenLabs failed",
+         *       "instance": "/api/v1/stories/1/tts",
+         *       "code": "tts.upstream_failed",
+         *       "hint": "Please try again later"
+         *     }
+         */
+        'application/problem+json': components['schemas']['ProblemDetails']
+      }
+    }
+    /** @description Service unavailable */
+    ServiceUnavailable: {
       headers: {
         [name: string]: unknown
       }
@@ -2489,8 +2628,6 @@ export interface operations {
        *     - Voice has no ElevenLabs voice ID configured
        *     - Story already has audio (use ?force=true to overwrite)
        *     - ElevenLabs voice ID not found
-       *     - ElevenLabs API key is invalid
-       *     - ElevenLabs rate limit exceeded
        */
       400: {
         headers: {
@@ -2503,6 +2640,8 @@ export interface operations {
       401: components['responses']['Unauthorized']
       403: components['responses']['Forbidden']
       404: components['responses']['NotFound']
+      422: components['responses']['UnprocessableEntity']
+      429: components['responses']['TooManyRequests']
       500: components['responses']['InternalServerError']
       /** @description TTS is not configured on the server */
       501: {
@@ -2522,6 +2661,67 @@ export interface operations {
           'application/problem+json': components['schemas']['ProblemDetails']
         }
       }
+      502: components['responses']['BadGateway']
+      503: components['responses']['ServiceUnavailable']
+    }
+  }
+  getSettingsTts: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Global TTS settings */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['TTSSettings']
+        }
+      }
+      401: components['responses']['Unauthorized']
+      403: components['responses']['Forbidden']
+      500: components['responses']['InternalServerError']
+      503: components['responses']['ServiceUnavailable']
+    }
+  }
+  patchSettingsTts: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        /**
+         * @example {
+         *       "stability": 0.7,
+         *       "seed": null
+         *     }
+         */
+        'application/json': components['schemas']['TTSSettingsUpdate']
+      }
+    }
+    responses: {
+      /** @description Global TTS settings updated */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['TTSSettings']
+        }
+      }
+      401: components['responses']['Unauthorized']
+      403: components['responses']['Forbidden']
+      422: components['responses']['UnprocessableEntity']
+      500: components['responses']['InternalServerError']
+      503: components['responses']['ServiceUnavailable']
     }
   }
   getStoriesId: {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -12,6 +12,8 @@ export interface VoiceInput {
 export type Station = components['schemas']['Station']
 export type StationInput = components['schemas']['StationInput']
 export type StationVoice = components['schemas']['StationVoice']
+export type TTSSettings = components['schemas']['TTSSettings']
+export type TTSSettingsUpdate = components['schemas']['TTSSettingsUpdate']
 export type Bulletin = components['schemas']['BulletinResponse']
 
 // UI uses Weekdays booleans, service converts to bitmask for API

--- a/src/routes/settings/ai/+page.svelte
+++ b/src/routes/settings/ai/+page.svelte
@@ -3,26 +3,9 @@
   import { RefreshCw, TriangleAlert } from '$lib/components/icons'
   import { PageHeader } from '$lib/components/ui'
   import TTSSettingsForm from './TTSSettingsForm.svelte'
-  import type { TTSSettings } from '$lib/types'
   import type { PageProps } from './$types'
 
   let { data }: PageProps = $props()
-
-  function settingsKey(settings: TTSSettings): string {
-    return JSON.stringify({
-      model: settings.model,
-      stability: settings.stability,
-      similarity_boost: settings.similarity_boost,
-      style: settings.style,
-      use_speaker_boost: settings.use_speaker_boost,
-      speed: settings.speed,
-      apply_text_normalization: settings.apply_text_normalization,
-      seed: settings.seed,
-      tts_style_prefix: settings.tts_style_prefix,
-      updated_at: settings.updated_at,
-      api_key_configured: settings.api_key_configured,
-    })
-  }
 
   async function reloadSettings(): Promise<void> {
     await invalidateAll()
@@ -64,7 +47,7 @@
       </button>
     </div>
   {:else if data.settings}
-    {#key settingsKey(data.settings)}
+    {#key JSON.stringify(data.settings)}
       <TTSSettingsForm settings={data.settings} />
     {/key}
   {/if}

--- a/src/routes/settings/ai/+page.svelte
+++ b/src/routes/settings/ai/+page.svelte
@@ -1,0 +1,308 @@
+<script lang="ts">
+  import { invalidateAll } from '$app/navigation'
+  import { settingsApi } from '$lib/api/settings'
+  import {
+    textNormalizationOptions,
+    toTTSSettingsFormData,
+    toTTSSettingsUpdate,
+    ttsModelOptions,
+    ttsSettingsSchema,
+    type TTSSettingsFormData,
+  } from '$lib/schemas/tts-settings'
+  import { Check, RefreshCw, Sparkles, TriangleAlert } from '$lib/components/icons'
+  import { toast } from '$lib/stores/toast'
+  import { formatDateTime } from '$lib/utils/format'
+  import { validateForm } from '$lib/utils/validation'
+  import { PageHeader, SelectInput, TextareaInput, TextInput } from '$lib/components/ui'
+  import type { TTSSettings } from '$lib/types'
+  import type { PageData } from './$types'
+
+  type NumericSettingField = 'stability' | 'similarity_boost' | 'style' | 'speed'
+
+  interface Props {
+    data: PageData
+  }
+
+  let { data }: Props = $props()
+
+  const numericSettings: {
+    field: NumericSettingField
+    label: string
+    min: number
+    max: number
+    step: number
+  }[] = [
+    { field: 'stability', label: 'Stabiliteit', min: 0, max: 1, step: 0.01 },
+    { field: 'similarity_boost', label: 'Similarity boost', min: 0, max: 1, step: 0.01 },
+    { field: 'style', label: 'Stijl', min: 0, max: 1, step: 0.01 },
+    { field: 'speed', label: 'Snelheid', min: 0.7, max: 1.2, step: 0.01 },
+  ]
+
+  function initialForm(settings: TTSSettings | null): TTSSettingsFormData {
+    if (settings) return toTTSSettingsFormData(settings)
+
+    return {
+      model: 'eleven_v3',
+      stability: 0.5,
+      similarity_boost: 0.75,
+      style: 0,
+      use_speaker_boost: true,
+      speed: 1,
+      apply_text_normalization: 'auto',
+      seed: '',
+      tts_style_prefix: '',
+    }
+  }
+
+  let form = $state<TTSSettingsFormData>(initialForm(null))
+  let errors = $state<Record<string, string>>({})
+  let submitting = $state(false)
+  let savedSettings = $state<TTSSettings | null>(null)
+  let loadedSettingsVersion = $state<string | null>(null)
+
+  const canEdit = $derived(!!savedSettings && !data.loadError)
+
+  $effect(() => {
+    const settings = data.settings
+    if (settings && settings.updated_at !== loadedSettingsVersion) {
+      savedSettings = settings
+      form = toTTSSettingsFormData(settings)
+      loadedSettingsVersion = settings.updated_at
+    } else if (data.loadError) {
+      savedSettings = null
+      loadedSettingsVersion = null
+    }
+  })
+
+  async function reloadSettings(): Promise<void> {
+    await invalidateAll()
+  }
+
+  async function handleSubmit(e: Event): Promise<void> {
+    e.preventDefault()
+
+    if (!canEdit || submitting) return
+
+    const result = validateForm(ttsSettingsSchema, form)
+    if (!result.success) {
+      errors = result.errors
+      return
+    }
+    errors = {}
+
+    submitting = true
+    try {
+      const updated = await settingsApi.updateTts(toTTSSettingsUpdate(result.data))
+      savedSettings = updated
+      form = toTTSSettingsFormData(updated)
+      toast.success('AI-instellingen opgeslagen')
+    } catch {
+      toast.error('Opslaan mislukt')
+    } finally {
+      submitting = false
+    }
+  }
+
+  function handleNumberInput(field: NumericSettingField, e: Event): void {
+    const value = Number((e.target as HTMLInputElement).value)
+    if (!Number.isNaN(value)) {
+      form = { ...form, [field]: value }
+    }
+  }
+</script>
+
+<div class="space-y-6">
+  <PageHeader
+    title="AI-instellingen"
+    subtitle="Globale ElevenLabs instellingen voor tekst-naar-spraak"
+  />
+
+  {#if data.loadError}
+    <div class="alert border-warning/30 bg-warning/10 text-warning-content">
+      <TriangleAlert
+        class="h-5 w-5"
+        aria-hidden="true"
+      />
+      <div>
+        <h2 class="font-semibold">AI-instellingen niet beschikbaar</h2>
+        <p class="text-sm">
+          {#if data.loadError.status}
+            HTTP {data.loadError.status}: {data.loadError.message}
+          {:else}
+            {data.loadError.message}
+          {/if}
+        </p>
+        {#if data.loadError.hint}
+          <p class="text-sm opacity-75">{data.loadError.hint}</p>
+        {/if}
+      </div>
+      <button
+        type="button"
+        class="btn btn-sm"
+        onclick={reloadSettings}
+      >
+        <RefreshCw class="h-4 w-4" />
+        Opnieuw laden
+      </button>
+    </div>
+  {:else if savedSettings}
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+      <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+        <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">
+          API-sleutel
+        </div>
+        <div class="mt-2">
+          <span
+            class={['badge', savedSettings.api_key_configured ? 'badge-success' : 'badge-warning']}
+          >
+            {savedSettings.api_key_configured ? 'Geconfigureerd' : 'Ontbreekt'}
+          </span>
+        </div>
+      </div>
+      <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+        <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">Model</div>
+        <div class="mt-2 font-semibold">{savedSettings.model}</div>
+      </div>
+      <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+        <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">
+          Bijgewerkt
+        </div>
+        <div class="mt-2 font-semibold">{formatDateTime(savedSettings.updated_at)}</div>
+      </div>
+    </div>
+
+    <form
+      onsubmit={handleSubmit}
+      class="card bg-base-100"
+    >
+      <div class="card-body space-y-6">
+        <div class="flex items-center gap-3">
+          <Sparkles
+            class="h-5 w-5 text-primary"
+            aria-hidden="true"
+          />
+          <h2 class="card-title">Tekst-naar-spraak</h2>
+        </div>
+
+        <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <SelectInput
+            id="model"
+            label="Model"
+            bind:value={form.model}
+            options={[...ttsModelOptions]}
+            error={errors.model}
+            disabled={submitting}
+          />
+
+          <SelectInput
+            id="apply_text_normalization"
+            label="Tekstnormalisatie"
+            bind:value={form.apply_text_normalization}
+            options={[...textNormalizationOptions]}
+            error={errors.apply_text_normalization}
+            disabled={submitting}
+          />
+        </div>
+
+        <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+          {#each numericSettings as setting (setting.field)}
+            <div class="space-y-4">
+              <div class="flex items-center justify-between gap-4">
+                <label
+                  class="font-medium"
+                  for={setting.field}
+                >
+                  {setting.label}
+                </label>
+                <input
+                  id="{setting.field}_number"
+                  type="number"
+                  class={[
+                    'input w-24 input-sm tabular-nums',
+                    errors[setting.field] && 'input-error',
+                  ]}
+                  min={setting.min}
+                  max={setting.max}
+                  step={setting.step}
+                  value={form[setting.field]}
+                  oninput={e => handleNumberInput(setting.field, e)}
+                  disabled={submitting}
+                  aria-label="{setting.label} waarde"
+                />
+              </div>
+              <input
+                id={setting.field}
+                type="range"
+                class="range w-full range-primary range-sm"
+                min={setting.min}
+                max={setting.max}
+                step={setting.step}
+                value={form[setting.field]}
+                oninput={e => handleNumberInput(setting.field, e)}
+                disabled={submitting}
+              />
+              {#if errors[setting.field]}
+                <p class="label text-error">{errors[setting.field]}</p>
+              {/if}
+            </div>
+          {/each}
+        </div>
+
+        <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <TextInput
+            id="seed"
+            label="Seed"
+            bind:value={form.seed}
+            error={errors.seed}
+            placeholder="Leeg voor willekeurig"
+            disabled={submitting}
+          />
+
+          <label class="fieldset">
+            <span class="fieldset-legend">Speaker boost</span>
+            <input
+              type="checkbox"
+              class="toggle toggle-primary"
+              bind:checked={form.use_speaker_boost}
+              disabled={submitting}
+            />
+          </label>
+        </div>
+
+        <TextareaInput
+          id="tts_style_prefix"
+          label="Eleven v3 stijlprefix"
+          bind:value={form.tts_style_prefix}
+          error={errors.tts_style_prefix}
+          rows={3}
+          placeholder="[nieuwslezer] "
+          disabled={submitting}
+        />
+
+        <div class="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            class="btn btn-ghost"
+            onclick={reloadSettings}
+            disabled={submitting}
+          >
+            <RefreshCw class="h-5 w-5" />
+            Herladen
+          </button>
+          <button
+            type="submit"
+            class="btn btn-primary"
+            disabled={submitting}
+          >
+            {#if submitting}
+              <span class="loading loading-sm loading-spinner"></span>
+            {:else}
+              <Check class="h-5 w-5" />
+            {/if}
+            Opslaan
+          </button>
+        </div>
+      </div>
+    </form>
+  {/if}
+</div>

--- a/src/routes/settings/ai/+page.svelte
+++ b/src/routes/settings/ai/+page.svelte
@@ -3,9 +3,26 @@
   import { RefreshCw, TriangleAlert } from '$lib/components/icons'
   import { PageHeader } from '$lib/components/ui'
   import TTSSettingsForm from './TTSSettingsForm.svelte'
+  import type { TTSSettings } from '$lib/types'
   import type { PageProps } from './$types'
 
   let { data }: PageProps = $props()
+
+  function settingsKey(settings: TTSSettings): string {
+    return JSON.stringify({
+      model: settings.model,
+      stability: settings.stability,
+      similarity_boost: settings.similarity_boost,
+      style: settings.style,
+      use_speaker_boost: settings.use_speaker_boost,
+      speed: settings.speed,
+      apply_text_normalization: settings.apply_text_normalization,
+      seed: settings.seed,
+      tts_style_prefix: settings.tts_style_prefix,
+      updated_at: settings.updated_at,
+      api_key_configured: settings.api_key_configured,
+    })
+  }
 
   async function reloadSettings(): Promise<void> {
     await invalidateAll()
@@ -47,7 +64,7 @@
       </button>
     </div>
   {:else if data.settings}
-    {#key data.settings.updated_at}
+    {#key settingsKey(data.settings)}
       <TTSSettingsForm settings={data.settings} />
     {/key}
   {/if}

--- a/src/routes/settings/ai/+page.svelte
+++ b/src/routes/settings/ai/+page.svelte
@@ -1,113 +1,14 @@
 <script lang="ts">
   import { invalidateAll } from '$app/navigation'
-  import { settingsApi } from '$lib/api/settings'
-  import {
-    textNormalizationOptions,
-    toTTSSettingsFormData,
-    toTTSSettingsUpdate,
-    ttsModelOptions,
-    ttsSettingsSchema,
-    type TTSSettingsFormData,
-  } from '$lib/schemas/tts-settings'
-  import { Check, RefreshCw, Sparkles, TriangleAlert } from '$lib/components/icons'
-  import { toast } from '$lib/stores/toast'
-  import { formatDateTime } from '$lib/utils/format'
-  import { validateForm } from '$lib/utils/validation'
-  import { PageHeader, SelectInput, TextareaInput, TextInput } from '$lib/components/ui'
-  import type { TTSSettings } from '$lib/types'
-  import type { PageData } from './$types'
+  import { RefreshCw, TriangleAlert } from '$lib/components/icons'
+  import { PageHeader } from '$lib/components/ui'
+  import TTSSettingsForm from './TTSSettingsForm.svelte'
+  import type { PageProps } from './$types'
 
-  type NumericSettingField = 'stability' | 'similarity_boost' | 'style' | 'speed'
-
-  interface Props {
-    data: PageData
-  }
-
-  let { data }: Props = $props()
-
-  const numericSettings: {
-    field: NumericSettingField
-    label: string
-    min: number
-    max: number
-    step: number
-  }[] = [
-    { field: 'stability', label: 'Stabiliteit', min: 0, max: 1, step: 0.01 },
-    { field: 'similarity_boost', label: 'Similarity boost', min: 0, max: 1, step: 0.01 },
-    { field: 'style', label: 'Stijl', min: 0, max: 1, step: 0.01 },
-    { field: 'speed', label: 'Snelheid', min: 0.7, max: 1.2, step: 0.01 },
-  ]
-
-  function initialForm(settings: TTSSettings | null): TTSSettingsFormData {
-    if (settings) return toTTSSettingsFormData(settings)
-
-    return {
-      model: 'eleven_v3',
-      stability: 0.5,
-      similarity_boost: 0.75,
-      style: 0,
-      use_speaker_boost: true,
-      speed: 1,
-      apply_text_normalization: 'auto',
-      seed: '',
-      tts_style_prefix: '',
-    }
-  }
-
-  let form = $state<TTSSettingsFormData>(initialForm(null))
-  let errors = $state<Record<string, string>>({})
-  let submitting = $state(false)
-  let savedSettings = $state<TTSSettings | null>(null)
-  let loadedSettingsVersion = $state<string | null>(null)
-
-  const canEdit = $derived(!!savedSettings && !data.loadError)
-
-  $effect(() => {
-    const settings = data.settings
-    if (settings && settings.updated_at !== loadedSettingsVersion) {
-      savedSettings = settings
-      form = toTTSSettingsFormData(settings)
-      loadedSettingsVersion = settings.updated_at
-    } else if (data.loadError) {
-      savedSettings = null
-      loadedSettingsVersion = null
-    }
-  })
+  let { data }: PageProps = $props()
 
   async function reloadSettings(): Promise<void> {
     await invalidateAll()
-  }
-
-  async function handleSubmit(e: Event): Promise<void> {
-    e.preventDefault()
-
-    if (!canEdit || submitting) return
-
-    const result = validateForm(ttsSettingsSchema, form)
-    if (!result.success) {
-      errors = result.errors
-      return
-    }
-    errors = {}
-
-    submitting = true
-    try {
-      const updated = await settingsApi.updateTts(toTTSSettingsUpdate(result.data))
-      savedSettings = updated
-      form = toTTSSettingsFormData(updated)
-      toast.success('AI-instellingen opgeslagen')
-    } catch {
-      toast.error('Opslaan mislukt')
-    } finally {
-      submitting = false
-    }
-  }
-
-  function handleNumberInput(field: NumericSettingField, e: Event): void {
-    const value = Number((e.target as HTMLInputElement).value)
-    if (!Number.isNaN(value)) {
-      form = { ...form, [field]: value }
-    }
   }
 </script>
 
@@ -118,9 +19,9 @@
   />
 
   {#if data.loadError}
-    <div class="alert border-warning/30 bg-warning/10 text-warning-content">
+    <div class="alert border-warning/30 bg-warning/10 text-base-content">
       <TriangleAlert
-        class="h-5 w-5"
+        class="h-5 w-5 text-warning"
         aria-hidden="true"
       />
       <div>
@@ -145,164 +46,9 @@
         Opnieuw laden
       </button>
     </div>
-  {:else if savedSettings}
-    <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
-      <div class="rounded-lg border border-base-300 bg-base-100 p-4">
-        <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">
-          API-sleutel
-        </div>
-        <div class="mt-2">
-          <span
-            class={['badge', savedSettings.api_key_configured ? 'badge-success' : 'badge-warning']}
-          >
-            {savedSettings.api_key_configured ? 'Geconfigureerd' : 'Ontbreekt'}
-          </span>
-        </div>
-      </div>
-      <div class="rounded-lg border border-base-300 bg-base-100 p-4">
-        <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">Model</div>
-        <div class="mt-2 font-semibold">{savedSettings.model}</div>
-      </div>
-      <div class="rounded-lg border border-base-300 bg-base-100 p-4">
-        <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">
-          Bijgewerkt
-        </div>
-        <div class="mt-2 font-semibold">{formatDateTime(savedSettings.updated_at)}</div>
-      </div>
-    </div>
-
-    <form
-      onsubmit={handleSubmit}
-      class="card bg-base-100"
-    >
-      <div class="card-body space-y-6">
-        <div class="flex items-center gap-3">
-          <Sparkles
-            class="h-5 w-5 text-primary"
-            aria-hidden="true"
-          />
-          <h2 class="card-title">Tekst-naar-spraak</h2>
-        </div>
-
-        <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
-          <SelectInput
-            id="model"
-            label="Model"
-            bind:value={form.model}
-            options={[...ttsModelOptions]}
-            error={errors.model}
-            disabled={submitting}
-          />
-
-          <SelectInput
-            id="apply_text_normalization"
-            label="Tekstnormalisatie"
-            bind:value={form.apply_text_normalization}
-            options={[...textNormalizationOptions]}
-            error={errors.apply_text_normalization}
-            disabled={submitting}
-          />
-        </div>
-
-        <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-          {#each numericSettings as setting (setting.field)}
-            <div class="space-y-4">
-              <div class="flex items-center justify-between gap-4">
-                <label
-                  class="font-medium"
-                  for={setting.field}
-                >
-                  {setting.label}
-                </label>
-                <input
-                  id="{setting.field}_number"
-                  type="number"
-                  class={[
-                    'input w-24 input-sm tabular-nums',
-                    errors[setting.field] && 'input-error',
-                  ]}
-                  min={setting.min}
-                  max={setting.max}
-                  step={setting.step}
-                  value={form[setting.field]}
-                  oninput={e => handleNumberInput(setting.field, e)}
-                  disabled={submitting}
-                  aria-label="{setting.label} waarde"
-                />
-              </div>
-              <input
-                id={setting.field}
-                type="range"
-                class="range w-full range-primary range-sm"
-                min={setting.min}
-                max={setting.max}
-                step={setting.step}
-                value={form[setting.field]}
-                oninput={e => handleNumberInput(setting.field, e)}
-                disabled={submitting}
-              />
-              {#if errors[setting.field]}
-                <p class="label text-error">{errors[setting.field]}</p>
-              {/if}
-            </div>
-          {/each}
-        </div>
-
-        <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
-          <TextInput
-            id="seed"
-            label="Seed"
-            bind:value={form.seed}
-            error={errors.seed}
-            placeholder="Leeg voor willekeurig"
-            disabled={submitting}
-          />
-
-          <label class="fieldset">
-            <span class="fieldset-legend">Speaker boost</span>
-            <input
-              type="checkbox"
-              class="toggle toggle-primary"
-              bind:checked={form.use_speaker_boost}
-              disabled={submitting}
-            />
-          </label>
-        </div>
-
-        <TextareaInput
-          id="tts_style_prefix"
-          label="Eleven v3 stijlprefix"
-          bind:value={form.tts_style_prefix}
-          error={errors.tts_style_prefix}
-          rows={3}
-          placeholder="[nieuwslezer] "
-          disabled={submitting}
-        />
-
-        <div class="flex justify-end gap-2 pt-2">
-          <button
-            type="button"
-            class="btn btn-ghost"
-            onclick={reloadSettings}
-            disabled={submitting}
-          >
-            <RefreshCw class="h-5 w-5" />
-            Herladen
-          </button>
-          <button
-            type="submit"
-            class="btn btn-primary"
-            disabled={submitting}
-          >
-            {#if submitting}
-              <span class="loading loading-sm loading-spinner"></span>
-            {:else}
-              <Check class="h-5 w-5" />
-            {/if}
-            Opslaan
-          </button>
-        </div>
-      </div>
-    </form>
+  {:else if data.settings}
+    {#key data.settings.updated_at}
+      <TTSSettingsForm settings={data.settings} />
+    {/key}
   {/if}
 </div>

--- a/src/routes/settings/ai/+page.ts
+++ b/src/routes/settings/ai/+page.ts
@@ -1,6 +1,8 @@
 import type { PageLoad } from './$types'
+import { redirect } from '@sveltejs/kit'
 import { ApiError } from '$lib/api/client'
 import { settingsApi } from '$lib/api/settings'
+import { resolveInternalHref } from '$lib/utils/routes'
 
 interface SettingsLoadError {
   status?: number
@@ -42,6 +44,10 @@ export const load: PageLoad = async ({ fetch }) => {
       loadError: null,
     }
   } catch (err) {
+    if (err instanceof ApiError && err.status === 401) {
+      throw redirect(303, resolveInternalHref('/login'))
+    }
+
     return {
       settings: null,
       loadError: toSettingsLoadError(err),

--- a/src/routes/settings/ai/+page.ts
+++ b/src/routes/settings/ai/+page.ts
@@ -1,0 +1,50 @@
+import type { PageLoad } from './$types'
+import { ApiError } from '$lib/api/client'
+import { settingsApi } from '$lib/api/settings'
+
+interface SettingsLoadError {
+  status?: number
+  message: string
+  hint?: string
+}
+
+interface ProblemDetails {
+  detail?: string
+  title?: string
+  hint?: string
+}
+
+function isProblemDetails(value: unknown): value is ProblemDetails {
+  return typeof value === 'object' && value !== null
+}
+
+function toSettingsLoadError(err: unknown): SettingsLoadError {
+  if (err instanceof ApiError) {
+    const details = isProblemDetails(err.details) ? err.details : undefined
+    return {
+      status: err.status || undefined,
+      message: details?.detail ?? details?.title ?? err.message,
+      hint: details?.hint,
+    }
+  }
+
+  if (err instanceof Error) {
+    return { message: err.message }
+  }
+
+  return { message: 'AI-instellingen laden mislukt' }
+}
+
+export const load: PageLoad = async ({ fetch }) => {
+  try {
+    return {
+      settings: await settingsApi.getTts(fetch),
+      loadError: null,
+    }
+  } catch (err) {
+    return {
+      settings: null,
+      loadError: toSettingsLoadError(err),
+    }
+  }
+}

--- a/src/routes/settings/ai/TTSSettingsForm.svelte
+++ b/src/routes/settings/ai/TTSSettingsForm.svelte
@@ -95,31 +95,26 @@
 
     submitting = true
     try {
-      const updated = await settingsApi.updateTts(toTTSSettingsUpdate(result.data))
-      const updatedForm = toTTSSettingsFormData(updated)
-
-      savedForm = updatedForm
-      form = { ...updatedForm }
+      await settingsApi.updateTts(toTTSSettingsUpdate(result.data))
       toast.success('AI-instellingen opgeslagen')
-      try {
-        await invalidateAll()
-      } catch {
-        toast.error('Opnieuw laden mislukt')
-      }
     } catch (err) {
       if (err instanceof ApiError && err.status === 422) {
         const validationErrors = validationErrorsFromDetails(err.details)
         if (Object.keys(validationErrors).length > 0) {
           errors = validationErrors
           toast.error('Controleer de velden')
+          submitting = false
           return
         }
       }
 
       toast.error('Opslaan mislukt')
-    } finally {
       submitting = false
+      return
     }
+
+    await invalidateAll()
+    submitting = false
   }
 
   function handleNumberInput(field: NumericSettingField, e: Event): void {

--- a/src/routes/settings/ai/TTSSettingsForm.svelte
+++ b/src/routes/settings/ai/TTSSettingsForm.svelte
@@ -1,0 +1,310 @@
+<script lang="ts">
+  import { invalidateAll } from '$app/navigation'
+  import { ApiError } from '$lib/api/client'
+  import { settingsApi } from '$lib/api/settings'
+  import {
+    textNormalizationOptions,
+    toTTSSettingsFormData,
+    toTTSSettingsUpdate,
+    ttsModelOptions,
+    ttsSettingsSchema,
+    type TTSSettingsFormData,
+  } from '$lib/schemas/tts-settings'
+  import { Check, RefreshCw, Sparkles } from '$lib/components/icons'
+  import { toast } from '$lib/stores/toast'
+  import { formatDateTime } from '$lib/utils/format'
+  import { validateForm } from '$lib/utils/validation'
+  import { SelectInput, TextareaInput, TextInput } from '$lib/components/ui'
+  import type { TTSSettings } from '$lib/types'
+
+  type NumericSettingField = 'stability' | 'similarity_boost' | 'style' | 'speed'
+
+  interface Props {
+    settings: TTSSettings
+  }
+
+  interface ValidationErrorDetails {
+    errors?: {
+      field?: string
+      message?: string
+    }[]
+  }
+
+  let { settings }: Props = $props()
+
+  const numericSettings: {
+    field: NumericSettingField
+    label: string
+    min: number
+    max: number
+    step: number
+  }[] = [
+    { field: 'stability', label: 'Stabiliteit', min: 0, max: 1, step: 0.01 },
+    { field: 'similarity_boost', label: 'Similarity boost', min: 0, max: 1, step: 0.01 },
+    { field: 'style', label: 'Stijl', min: 0, max: 1, step: 0.01 },
+    { field: 'speed', label: 'Snelheid', min: 0.7, max: 1.2, step: 0.01 },
+  ]
+
+  function initialSettings(): TTSSettings {
+    return settings
+  }
+
+  function initialForm(): TTSSettingsFormData {
+    return toTTSSettingsFormData(initialSettings())
+  }
+
+  let currentSettings = $state<TTSSettings>(initialSettings())
+  let savedForm = $state<TTSSettingsFormData>(initialForm())
+  let form = $state<TTSSettingsFormData>({ ...initialForm() })
+  let errors = $state<Record<string, string>>({})
+  let submitting = $state(false)
+
+  const isDirty = $derived(!formsEqual(form, savedForm))
+  const reloadLabel = $derived(isDirty ? 'Wijzigingen verwerpen' : 'Herladen')
+
+  function formsEqual(a: TTSSettingsFormData, b: TTSSettingsFormData): boolean {
+    return (
+      a.model === b.model &&
+      a.stability === b.stability &&
+      a.similarity_boost === b.similarity_boost &&
+      a.style === b.style &&
+      a.use_speaker_boost === b.use_speaker_boost &&
+      a.speed === b.speed &&
+      a.apply_text_normalization === b.apply_text_normalization &&
+      a.seed === b.seed &&
+      a.tts_style_prefix === b.tts_style_prefix
+    )
+  }
+
+  function isValidationErrorDetails(value: unknown): value is ValidationErrorDetails {
+    return typeof value === 'object' && value !== null && 'errors' in value
+  }
+
+  function validationErrorsFromDetails(details: unknown): Record<string, string> {
+    if (!isValidationErrorDetails(details) || !Array.isArray(details.errors)) return {}
+
+    return details.errors.reduce<Record<string, string>>((result, error) => {
+      if (error.field && error.message && !result[error.field]) {
+        result[error.field] = error.message
+      }
+      return result
+    }, {})
+  }
+
+  async function reloadSettings(): Promise<void> {
+    if (isDirty && !confirm('Onopgeslagen wijzigingen verwerpen en opnieuw laden?')) return
+
+    if (isDirty) {
+      form = { ...savedForm }
+      errors = {}
+    }
+
+    await invalidateAll()
+  }
+
+  async function handleSubmit(e: Event): Promise<void> {
+    e.preventDefault()
+
+    if (submitting) return
+
+    const result = validateForm(ttsSettingsSchema, form)
+    if (!result.success) {
+      errors = result.errors
+      return
+    }
+    errors = {}
+
+    submitting = true
+    try {
+      const updated = await settingsApi.updateTts(toTTSSettingsUpdate(result.data))
+      const updatedForm = toTTSSettingsFormData(updated)
+
+      currentSettings = updated
+      savedForm = updatedForm
+      form = { ...updatedForm }
+      toast.success('AI-instellingen opgeslagen')
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 422) {
+        const validationErrors = validationErrorsFromDetails(err.details)
+        if (Object.keys(validationErrors).length > 0) {
+          errors = validationErrors
+          toast.error('Controleer de velden')
+          return
+        }
+      }
+
+      toast.error('Opslaan mislukt')
+    } finally {
+      submitting = false
+    }
+  }
+
+  function handleNumberInput(field: NumericSettingField, e: Event): void {
+    const input = e.target as HTMLInputElement
+    if (input.value === '') return
+
+    const value = Number(input.value)
+    if (!Number.isNaN(value)) {
+      form = { ...form, [field]: value }
+    }
+  }
+</script>
+
+<div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+  <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+    <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">API-sleutel</div>
+    <div class="mt-2">
+      <span
+        class={['badge', currentSettings.api_key_configured ? 'badge-success' : 'badge-warning']}
+      >
+        {currentSettings.api_key_configured ? 'Geconfigureerd' : 'Ontbreekt'}
+      </span>
+    </div>
+  </div>
+  <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+    <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">Model</div>
+    <div class="mt-2 font-semibold">{currentSettings.model}</div>
+  </div>
+  <div class="rounded-lg border border-base-300 bg-base-100 p-4">
+    <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">Bijgewerkt</div>
+    <div class="mt-2 font-semibold">{formatDateTime(currentSettings.updated_at)}</div>
+  </div>
+</div>
+
+<form
+  onsubmit={handleSubmit}
+  class="card bg-base-100"
+>
+  <div class="card-body space-y-6">
+    <div class="flex items-center gap-3">
+      <Sparkles
+        class="h-5 w-5 text-primary"
+        aria-hidden="true"
+      />
+      <h2 class="card-title">Tekst-naar-spraak</h2>
+    </div>
+
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <SelectInput
+        id="model"
+        label="Model"
+        bind:value={form.model}
+        options={ttsModelOptions}
+        error={errors.model}
+        disabled={submitting}
+      />
+
+      <SelectInput
+        id="apply_text_normalization"
+        label="Tekstnormalisatie"
+        bind:value={form.apply_text_normalization}
+        options={textNormalizationOptions}
+        error={errors.apply_text_normalization}
+        disabled={submitting}
+      />
+    </div>
+
+    <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+      {#each numericSettings as setting (setting.field)}
+        <div class="space-y-4">
+          <div class="flex items-center justify-between gap-4">
+            <label
+              class="font-medium"
+              for="{setting.field}_number"
+            >
+              {setting.label}
+            </label>
+            <input
+              id="{setting.field}_number"
+              type="number"
+              class={['input w-24 input-sm tabular-nums', errors[setting.field] && 'input-error']}
+              min={setting.min}
+              max={setting.max}
+              step={setting.step}
+              value={form[setting.field]}
+              oninput={e => handleNumberInput(setting.field, e)}
+              disabled={submitting}
+            />
+          </div>
+          <input
+            id={setting.field}
+            type="range"
+            class="range w-full range-primary range-sm"
+            min={setting.min}
+            max={setting.max}
+            step={setting.step}
+            value={form[setting.field]}
+            oninput={e => handleNumberInput(setting.field, e)}
+            disabled={submitting}
+            aria-label="{setting.label} slider"
+          />
+          {#if errors[setting.field]}
+            <p class="label text-error">{errors[setting.field]}</p>
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <TextInput
+        id="seed"
+        label="Seed"
+        bind:value={form.seed}
+        error={errors.seed}
+        placeholder="Leeg voor willekeurig"
+        disabled={submitting}
+      />
+
+      <fieldset class="fieldset">
+        <label
+          class="fieldset-legend"
+          for="use_speaker_boost"
+        >
+          Speaker boost
+        </label>
+        <input
+          id="use_speaker_boost"
+          type="checkbox"
+          class="toggle toggle-primary"
+          bind:checked={form.use_speaker_boost}
+          disabled={submitting}
+        />
+      </fieldset>
+    </div>
+
+    <TextareaInput
+      id="tts_style_prefix"
+      label="Eleven v3 stijlprefix"
+      bind:value={form.tts_style_prefix}
+      error={errors.tts_style_prefix}
+      hint="Alleen toegepast bij model Eleven v3"
+      rows={3}
+      placeholder="[nieuwslezer] "
+      disabled={submitting}
+    />
+
+    <div class="flex justify-end gap-2 pt-2">
+      <button
+        type="button"
+        class="btn btn-ghost"
+        onclick={reloadSettings}
+        disabled={submitting}
+      >
+        <RefreshCw class="h-5 w-5" />
+        {reloadLabel}
+      </button>
+      <button
+        type="submit"
+        class="btn btn-primary"
+        disabled={submitting || !isDirty}
+      >
+        {#if submitting}
+          <span class="loading loading-sm loading-spinner"></span>
+        {:else}
+          <Check class="h-5 w-5" />
+        {/if}
+        Opslaan
+      </button>
+    </div>
+  </div>
+</form>

--- a/src/routes/settings/ai/TTSSettingsForm.svelte
+++ b/src/routes/settings/ai/TTSSettingsForm.svelte
@@ -15,7 +15,7 @@
   import { formatDateTime } from '$lib/utils/format'
   import { validateForm } from '$lib/utils/validation'
   import { SelectInput, TextareaInput, TextInput } from '$lib/components/ui'
-  import type { TTSSettings } from '$lib/types'
+  import type { components, TTSSettings } from '$lib/types'
 
   type NumericSettingField = 'stability' | 'similarity_boost' | 'style' | 'speed'
 
@@ -23,12 +23,7 @@
     settings: TTSSettings
   }
 
-  interface ValidationErrorDetails {
-    errors?: {
-      field?: string
-      message?: string
-    }[]
-  }
+  type ValidationErrorDetails = components['schemas']['ValidationError']
 
   let { settings }: Props = $props()
 
@@ -45,6 +40,8 @@
     { field: 'speed', label: 'Snelheid', min: 0.7, max: 1.2, step: 0.01 },
   ]
 
+  // Svelte warns when prop values are captured directly into state initializers.
+  // These lazy readers make the keyed component's one-time form initialization explicit.
   function initialSettings(): TTSSettings {
     return settings
   }
@@ -55,26 +52,12 @@
 
   let currentSettings = $state<TTSSettings>(initialSettings())
   let savedForm = $state<TTSSettingsFormData>(initialForm())
-  let form = $state<TTSSettingsFormData>({ ...initialForm() })
+  let form = $state<TTSSettingsFormData>(initialForm())
   let errors = $state<Record<string, string>>({})
   let submitting = $state(false)
 
-  const isDirty = $derived(!formsEqual(form, savedForm))
+  const isDirty = $derived(JSON.stringify(form) !== JSON.stringify(savedForm))
   const reloadLabel = $derived(isDirty ? 'Wijzigingen verwerpen' : 'Herladen')
-
-  function formsEqual(a: TTSSettingsFormData, b: TTSSettingsFormData): boolean {
-    return (
-      a.model === b.model &&
-      a.stability === b.stability &&
-      a.similarity_boost === b.similarity_boost &&
-      a.style === b.style &&
-      a.use_speaker_boost === b.use_speaker_boost &&
-      a.speed === b.speed &&
-      a.apply_text_normalization === b.apply_text_normalization &&
-      a.seed === b.seed &&
-      a.tts_style_prefix === b.tts_style_prefix
-    )
-  }
 
   function isValidationErrorDetails(value: unknown): value is ValidationErrorDetails {
     return typeof value === 'object' && value !== null && 'errors' in value

--- a/src/routes/settings/ai/TTSSettingsForm.svelte
+++ b/src/routes/settings/ai/TTSSettingsForm.svelte
@@ -95,26 +95,27 @@
 
     submitting = true
     try {
-      await settingsApi.updateTts(toTTSSettingsUpdate(result.data))
-      toast.success('AI-instellingen opgeslagen')
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 422) {
-        const validationErrors = validationErrorsFromDetails(err.details)
-        if (Object.keys(validationErrors).length > 0) {
-          errors = validationErrors
-          toast.error('Controleer de velden')
-          submitting = false
-          return
+      try {
+        await settingsApi.updateTts(toTTSSettingsUpdate(result.data))
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 422) {
+          const validationErrors = validationErrorsFromDetails(err.details)
+          if (Object.keys(validationErrors).length > 0) {
+            errors = validationErrors
+            toast.error('Controleer de velden')
+            return
+          }
         }
+
+        toast.error('Opslaan mislukt')
+        return
       }
 
-      toast.error('Opslaan mislukt')
+      toast.success('AI-instellingen opgeslagen')
+      await invalidateAll()
+    } finally {
       submitting = false
-      return
     }
-
-    await invalidateAll()
-    submitting = false
   }
 
   function handleNumberInput(field: NumericSettingField, e: Event): void {

--- a/src/routes/settings/ai/TTSSettingsForm.svelte
+++ b/src/routes/settings/ai/TTSSettingsForm.svelte
@@ -41,22 +41,18 @@
   ]
 
   // Svelte warns when prop values are captured directly into state initializers.
-  // These lazy readers make the keyed component's one-time form initialization explicit.
-  function initialSettings(): TTSSettings {
-    return settings
-  }
-
+  // This lazy reader makes the keyed component's one-time form initialization explicit.
   function initialForm(): TTSSettingsFormData {
-    return toTTSSettingsFormData(initialSettings())
+    return toTTSSettingsFormData(settings)
   }
 
-  let currentSettings = $state<TTSSettings>(initialSettings())
   let savedForm = $state<TTSSettingsFormData>(initialForm())
   let form = $state<TTSSettingsFormData>(initialForm())
   let errors = $state<Record<string, string>>({})
   let submitting = $state(false)
 
   const isDirty = $derived(JSON.stringify(form) !== JSON.stringify(savedForm))
+  const isV3Model = $derived(form.model === 'eleven_v3')
   const reloadLabel = $derived(isDirty ? 'Wijzigingen verwerpen' : 'Herladen')
 
   function isValidationErrorDetails(value: unknown): value is ValidationErrorDetails {
@@ -102,10 +98,14 @@
       const updated = await settingsApi.updateTts(toTTSSettingsUpdate(result.data))
       const updatedForm = toTTSSettingsFormData(updated)
 
-      currentSettings = updated
       savedForm = updatedForm
       form = { ...updatedForm }
       toast.success('AI-instellingen opgeslagen')
+      try {
+        await invalidateAll()
+      } catch {
+        toast.error('Opnieuw laden mislukt')
+      }
     } catch (err) {
       if (err instanceof ApiError && err.status === 422) {
         const validationErrors = validationErrorsFromDetails(err.details)
@@ -137,20 +137,18 @@
   <div class="rounded-lg border border-base-300 bg-base-100 p-4">
     <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">API-sleutel</div>
     <div class="mt-2">
-      <span
-        class={['badge', currentSettings.api_key_configured ? 'badge-success' : 'badge-warning']}
-      >
-        {currentSettings.api_key_configured ? 'Geconfigureerd' : 'Ontbreekt'}
+      <span class={['badge', settings.api_key_configured ? 'badge-success' : 'badge-warning']}>
+        {settings.api_key_configured ? 'Geconfigureerd' : 'Ontbreekt'}
       </span>
     </div>
   </div>
   <div class="rounded-lg border border-base-300 bg-base-100 p-4">
     <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">Model</div>
-    <div class="mt-2 font-semibold">{currentSettings.model}</div>
+    <div class="mt-2 font-semibold">{settings.model}</div>
   </div>
   <div class="rounded-lg border border-base-300 bg-base-100 p-4">
     <div class="text-xs font-medium tracking-wide text-base-content/60 uppercase">Bijgewerkt</div>
-    <div class="mt-2 font-semibold">{formatDateTime(currentSettings.updated_at)}</div>
+    <div class="mt-2 font-semibold">{formatDateTime(settings.updated_at)}</div>
   </div>
 </div>
 
@@ -260,10 +258,12 @@
       label="Eleven v3 stijlprefix"
       bind:value={form.tts_style_prefix}
       error={errors.tts_style_prefix}
-      hint="Alleen toegepast bij model Eleven v3"
+      hint={isV3Model
+        ? 'Alleen toegepast bij model Eleven v3'
+        : 'Niet beschikbaar voor het huidige model'}
       rows={3}
       placeholder="[nieuwslezer] "
-      disabled={submitting}
+      disabled={submitting || !isV3Model}
     />
 
     <div class="flex justify-end gap-2 pt-2">


### PR DESCRIPTION
## Summary
- regenerate OpenAPI types from Babbel v0.10.0, including `GET/PATCH /api/v1/settings/tts` and TTS error responses
- add a typed settings API client and form schema for all new global ElevenLabs TTS options
- wire the admin `AI-instellingen` navigation item to `/settings/ai` with status display, validation, save/reload actions, and 503/problem-details handling

## OpenAPI source
- Backend release: https://github.com/oszuidwest/zwfm-babbel/releases/tag/v0.10.0
- Relevant endpoint: `GET/PATCH /api/v1/settings/tts`

## Verification
- `npx @sveltejs/mcp svelte-autofixer ./src/routes/settings/ai/+page.svelte --svelte-version 5`
- `PUBLIC_API_URL= npm run check`
- `PUBLIC_API_URL= npm run lint`
- `npm run format:check`
- `npm run types:check`
- `PUBLIC_API_URL= npm run build`

## Runtime note
No production backend is available yet for end-to-end verification against a live `tts_settings` row. The page handles backend problem-details responses, including 503 migration/seed-row states, but real save/load behavior still needs validation once the v0.10.0 backend is deployed.