### PR TITLE
feat: add Uitspraakregels page for ElevenLabs pronunciation dictionary

### DIFF
--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -16,6 +16,21 @@ interface RequestOptions extends Omit<RequestInit, 'body'> {
   fetch?: FetchFn
 }
 
+export interface ProblemFieldError {
+  field?: string
+  message?: string
+}
+
+export interface ProblemDetails {
+  code?: string
+  type?: string
+  title?: string
+  status?: number
+  detail?: string
+  hint?: string
+  errors?: ProblemFieldError[]
+}
+
 class ApiError extends Error {
   constructor(
     public status: number,
@@ -25,6 +40,32 @@ class ApiError extends Error {
     super(message)
     this.name = 'ApiError'
   }
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string'
+}
+
+function isProblemFieldError(value: unknown): value is ProblemFieldError {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as Record<string, unknown>
+  return isOptionalString(candidate.field) && isOptionalString(candidate.message)
+}
+
+function isProblemDetails(value: unknown): value is ProblemDetails {
+  if (typeof value !== 'object' || value === null) return false
+
+  const candidate = value as Record<string, unknown>
+  return (
+    isOptionalString(candidate.code) &&
+    isOptionalString(candidate.type) &&
+    isOptionalString(candidate.title) &&
+    (candidate.status === undefined || typeof candidate.status === 'number') &&
+    isOptionalString(candidate.detail) &&
+    isOptionalString(candidate.hint) &&
+    (candidate.errors === undefined ||
+      (Array.isArray(candidate.errors) && candidate.errors.every(isProblemFieldError)))
+  )
 }
 
 async function parseErrorResponse(
@@ -53,6 +94,9 @@ function handleFetchError(err: unknown, timeoutMessage: string): never {
   if (err instanceof Error && err.name === 'AbortError') {
     throw new ApiError(0, timeoutMessage)
   }
+  if (err instanceof TypeError) {
+    throw new ApiError(0, 'Network error')
+  }
   throw err
 }
 
@@ -75,33 +119,35 @@ async function request<T>(endpoint: string, options: RequestOptions = {}): Promi
     }
   }
 
+  const requestBody = body ? JSON.stringify(body) : undefined
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), 30000)
 
+  let response: Response
   try {
-    const response = await fetchFn(url, {
+    response = await fetchFn(url, {
       ...fetchOptions,
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
         ...fetchOptions.headers,
       },
-      body: body ? JSON.stringify(body) : undefined,
+      body: requestBody,
       signal: controller.signal,
     })
-
-    clearTimeout(timeoutId)
-
-    if (!response.ok) {
-      const { message, details } = await parseErrorResponse(response, 'Request failed')
-      throw new ApiError(response.status, message, details)
-    }
-
-    return parseResponseBody<T>(response)
   } catch (err) {
     clearTimeout(timeoutId)
     handleFetchError(err, 'Request timeout')
   }
+
+  clearTimeout(timeoutId)
+
+  if (!response.ok) {
+    const { message, details } = await parseErrorResponse(response, 'Request failed')
+    throw new ApiError(response.status, message, details)
+  }
+
+  return parseResponseBody<T>(response)
 }
 
 async function upload<T>(
@@ -119,27 +165,28 @@ async function upload<T>(
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), 120000) // 2 minute timeout for uploads
 
+  let response: Response
   try {
-    const response = await fetchFn(url, {
+    response = await fetchFn(url, {
       method: 'POST',
       credentials: 'include',
       // Don't set Content-Type - browser will set it with boundary for multipart/form-data
       body: formData,
       signal: controller.signal,
     })
-
-    clearTimeout(timeoutId)
-
-    if (!response.ok) {
-      const { message, details } = await parseErrorResponse(response, 'Upload failed')
-      throw new ApiError(response.status, message, details)
-    }
-
-    return parseResponseBody<T>(response)
   } catch (err) {
     clearTimeout(timeoutId)
     handleFetchError(err, 'Upload timeout')
   }
+
+  clearTimeout(timeoutId)
+
+  if (!response.ok) {
+    const { message, details } = await parseErrorResponse(response, 'Upload failed')
+    throw new ApiError(response.status, message, details)
+  }
+
+  return parseResponseBody<T>(response)
 }
 
 export function getMediaUrl(path: string | undefined | null): string | undefined {
@@ -171,5 +218,5 @@ export const api = {
   upload,
 }
 
-export { ApiError }
+export { ApiError, isProblemDetails }
 export type { FetchFn, PaginationFilters }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -119,7 +119,7 @@ async function request<T>(endpoint: string, options: RequestOptions = {}): Promi
     }
   }
 
-  const requestBody = body ? JSON.stringify(body) : undefined
+  const requestBody = body !== undefined ? JSON.stringify(body) : undefined
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), 30000)
 

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -1,9 +1,20 @@
 import { api, type FetchFn } from './client'
-import type { TTSSettings, TTSSettingsUpdate } from '$lib/types'
+import type {
+  PronunciationRulesList,
+  PronunciationRulesUpdate,
+  TTSSettings,
+  TTSSettingsUpdate,
+} from '$lib/types'
 
 export const settingsApi = {
   getTts: (customFetch?: FetchFn) => api.get<TTSSettings>('/settings/tts', undefined, customFetch),
 
   updateTts: (data: TTSSettingsUpdate, customFetch?: FetchFn) =>
     api.patch<TTSSettings>('/settings/tts', data, customFetch),
+
+  getTtsPronunciations: (customFetch?: FetchFn) =>
+    api.get<PronunciationRulesList>('/settings/tts/pronunciations', undefined, customFetch),
+
+  updateTtsPronunciations: (data: PronunciationRulesUpdate, customFetch?: FetchFn) =>
+    api.put<PronunciationRulesList>('/settings/tts/pronunciations', data, customFetch),
 }

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -8,6 +8,7 @@
   import {
     Radio,
     Mic,
+    BookOpen,
     FileText,
     Podcast,
     Users,
@@ -31,6 +32,10 @@
     { path: '/voices', label: 'Stemmen', icon: Mic },
     { path: '/stories', label: 'Berichten', icon: FileText },
     { path: '/bulletins', label: 'Bulletins', icon: Podcast },
+  ]
+
+  const aiNavItems: NavItem[] = [
+    { path: '/pronunciations', label: 'Uitspraakregels', icon: BookOpen },
   ]
 
   const adminNavItems: NavItem[] = [
@@ -143,6 +148,26 @@
               </a>
             </li>
           {/each}
+
+          <!-- AI section (editors + admins) -->
+          {#if auth.canEditPronunciations}
+            <li class="mt-4 menu-title tracking-widest uppercase">AI</li>
+            {#each aiNavItems as item (item.path)}
+              {@const Icon = item.icon}
+              <li>
+                <a
+                  href={resolveInternalHref(item.path)}
+                  class={{ 'menu-active': isActive(item.path) }}
+                >
+                  <Icon
+                    aria-hidden="true"
+                    class="h-6 w-6"
+                  />
+                  {item.label}
+                </a>
+              </li>
+            {/each}
+          {/if}
 
           <!-- Admin section -->
           {#if auth.isAdmin}

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -145,7 +145,7 @@
             </li>
           {/each}
 
-          {#if auth.canEditPronunciations}
+          {#if auth.canViewPronunciations}
             <li class="mt-4 menu-title tracking-widest uppercase">AI</li>
             {#each aiNavItems as item (item.path)}
               {@const Icon = item.icon}

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -61,7 +61,6 @@
   />
 
   <div class="drawer-content flex flex-col">
-    <!-- Mobile navbar -->
     <div class="navbar bg-base-100 lg:hidden">
       <div class="flex-none">
         <label
@@ -93,7 +92,6 @@
       </div>
     </div>
 
-    <!-- Page content -->
     <main class="min-h-screen flex-1 bg-base-200">
       <div class="p-4 lg:p-8">
         {@render children()}
@@ -108,7 +106,6 @@
       aria-label="Menu sluiten"
     ></label>
     <aside class="flex min-h-full w-80 flex-col bg-base-100">
-      <!-- Logo -->
       <div class="border-b border-base-300 p-6">
         <a
           href={resolveInternalHref('/')}
@@ -129,7 +126,6 @@
         </a>
       </div>
 
-      <!-- Navigation -->
       <nav class="flex-1 p-5">
         <ul class="menu gap-2 menu-md [&_a]:rounded-lg">
           <li class="menu-title tracking-widest uppercase">Menu</li>
@@ -149,7 +145,6 @@
             </li>
           {/each}
 
-          <!-- AI section (editors + admins) -->
           {#if auth.canEditPronunciations}
             <li class="mt-4 menu-title tracking-widest uppercase">AI</li>
             {#each aiNavItems as item (item.path)}
@@ -169,7 +164,6 @@
             {/each}
           {/if}
 
-          <!-- Admin section -->
           {#if auth.isAdmin}
             <li class="mt-4 menu-title tracking-widest uppercase">Admin</li>
             {#each adminNavItems as item (item.path)}
@@ -191,7 +185,6 @@
         </ul>
       </nav>
 
-      <!-- User info -->
       <div class="border-t border-base-300 p-4">
         <div class="flex items-center gap-3">
           <div class="avatar-online avatar avatar-placeholder">

--- a/src/lib/components/icons.ts
+++ b/src/lib/components/icons.ts
@@ -4,6 +4,7 @@ export {
   Zap,
   ArchiveX,
   AudioWaveform,
+  BookOpen,
   CassetteTape,
   Check,
   CircleCheckBig,

--- a/src/lib/schemas/pronunciations.ts
+++ b/src/lib/schemas/pronunciations.ts
@@ -30,3 +30,18 @@ export const pronunciationRulesSchema = z
   })
 
 export type PronunciationRuleFormData = z.infer<typeof pronunciationRuleSchema>
+
+export const pronunciationRuleFieldNames = [
+  'string_to_replace',
+  'alias',
+  'case_sensitive',
+  'word_boundaries',
+] as const
+
+export type PronunciationRuleField = (typeof pronunciationRuleFieldNames)[number]
+
+const pronunciationRuleFieldSet = new Set<string>(pronunciationRuleFieldNames)
+
+export function isPronunciationRuleField(field: string): field is PronunciationRuleField {
+  return pronunciationRuleFieldSet.has(field)
+}

--- a/src/lib/schemas/pronunciations.ts
+++ b/src/lib/schemas/pronunciations.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+
+export const pronunciationRuleSchema = z.object({
+  string_to_replace: z.string().trim().min(1, 'Woord is verplicht'),
+  alias: z.string().trim().min(1, 'Uitspraak is verplicht'),
+  case_sensitive: z.boolean(),
+  word_boundaries: z.boolean(),
+})
+
+export const pronunciationRulesSchema = z
+  .object({
+    rules: z.array(pronunciationRuleSchema).max(5000, 'Maximaal 5000 regels toegestaan'),
+  })
+  .superRefine((data, ctx) => {
+    const seen = new Map<string, number>()
+    data.rules.forEach((rule, i) => {
+      const key = rule.string_to_replace.trim()
+      if (!key) return
+      const prev = seen.get(key)
+      if (prev !== undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['rules', i, 'string_to_replace'],
+          message: `Dubbele invoer (zelfde als regel ${prev + 1})`,
+        })
+      } else {
+        seen.set(key, i)
+      }
+    })
+  })
+
+export type PronunciationRuleFormData = z.infer<typeof pronunciationRuleSchema>

--- a/src/lib/stores/auth.svelte.ts
+++ b/src/lib/stores/auth.svelte.ts
@@ -12,6 +12,7 @@ export class AuthStore {
   checked = $state(false)
 
   isAdmin = $derived(this.user?.role === 'admin')
+  canEditPronunciations = $derived(this.user?.role === 'admin' || this.user?.role === 'editor')
 
   private checkPromise: Promise<boolean> | null = null
 

--- a/src/lib/stores/auth.svelte.ts
+++ b/src/lib/stores/auth.svelte.ts
@@ -12,6 +12,7 @@ export class AuthStore {
   checked = $state(false)
 
   isAdmin = $derived(this.user?.role === 'admin')
+  canViewPronunciations = $derived(!!this.user)
   canEditPronunciations = $derived(this.user?.role === 'admin' || this.user?.role === 'editor')
 
   private checkPromise: Promise<boolean> | null = null

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -405,7 +405,7 @@ export interface paths {
      *     - Story must have a `voice_id` assigned
      *     - The assigned voice must have an `elevenlabs_voice_id` configured
      *
-     *     **Audio pipeline:** ElevenLabs returns MP3 → converted to 48kHz mono WAV → stored as story audio.
+     *     **Audio pipeline:** ElevenLabs returns Opus (`opus_48000_128`) → converted to 48kHz mono WAV → stored as story audio.
      */
     post: operations['postStoriesIdTts']
     delete?: never
@@ -445,6 +445,34 @@ export interface paths {
      *     these settings.
      */
     patch: operations['patchSettingsTts']
+    trace?: never
+  }
+  '/api/v1/settings/tts/pronunciations': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get TTS pronunciation rules
+     * @description Returns the alias pronunciation rules from the single Babbel-managed
+     *     ElevenLabs pronunciation dictionary. No upstream call is made until a
+     *     dictionary has been created by saving at least one rule.
+     */
+    get: operations['getSettingsTtsPronunciations']
+    /**
+     * Replace TTS pronunciation rules
+     * @description Replaces the complete alias-rule set for the Babbel-managed ElevenLabs
+     *     pronunciation dictionary. The dictionary is created lazily on the first
+     *     non-empty save. Editors and admins can write; viewers can only read.
+     */
+    put: operations['putSettingsTtsPronunciations']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
     trace?: never
   }
   '/api/v1/stories/{id}': {
@@ -989,6 +1017,38 @@ export interface components {
       /** @description Set to null to clear the stored seed. */
       seed?: number | null
       tts_style_prefix?: string
+    }
+    PronunciationRule: {
+      /** @description Text fragment ElevenLabs should replace before synthesis. */
+      string_to_replace: string
+      /** @description Replacement pronunciation for the text fragment. */
+      alias: string
+      /**
+       * @description Whether matching is case-sensitive. Defaults to true when omitted.
+       * @default true
+       */
+      case_sensitive: boolean | null
+      /**
+       * @description Whether matching is constrained to word boundaries. Defaults to true when omitted.
+       * @default true
+       */
+      word_boundaries: boolean | null
+    }
+    PronunciationRulesList: {
+      rules: components['schemas']['PronunciationRule'][]
+      /** @description ElevenLabs latest version ID. Null until a dictionary exists. */
+      latest_version_id: string | null
+      /**
+       * Format: date-time
+       * @description Dictionary creation time. Null until a dictionary exists.
+       */
+      created_at: string | null
+      /** @description Warns when the upstream dictionary is missing and will be recreated, or when non-alias ElevenLabs rules were discarded from the editor-facing list. */
+      warning?: string
+    }
+    PronunciationRulesUpdate: {
+      /** @description Complete replacement alias-rule set. Empty array clears all rules. */
+      rules: components['schemas']['PronunciationRule'][]
     }
     /** @description Represents the relationship between a station and voice with station-specific jingle configuration */
     StationVoice: {
@@ -1563,6 +1623,7 @@ export interface components {
      *     - `https://babbel.api/problems/duplicate` - Duplicate resource (e.g., station name already exists)
      *     - `https://babbel.api/problems/dependency-constraint` - Resource has dependencies that prevent deletion
      *     - `https://babbel.api/problems/admin-constraint` - Cannot delete last admin user
+     *     - `https://babbel.api/problems/pronunciation_rules.conflict` - Pronunciation dictionary changed concurrently
      */
     Conflict: {
       headers: {
@@ -2721,6 +2782,113 @@ export interface operations {
       403: components['responses']['Forbidden']
       422: components['responses']['UnprocessableEntity']
       500: components['responses']['InternalServerError']
+      503: components['responses']['ServiceUnavailable']
+    }
+  }
+  getSettingsTtsPronunciations: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Current pronunciation rules */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PronunciationRulesList']
+        }
+      }
+      401: components['responses']['Unauthorized']
+      403: components['responses']['Forbidden']
+      422: components['responses']['UnprocessableEntity']
+      429: components['responses']['TooManyRequests']
+      500: components['responses']['InternalServerError']
+      /** @description TTS is not configured on the server */
+      501: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          /**
+           * @example {
+           *       "type": "https://babbel.api/problems/tts.not_configured",
+           *       "title": "Not Implemented",
+           *       "status": 501,
+           *       "detail": "Text-to-speech is not configured",
+           *       "hint": "Set BABBEL_ELEVENLABS_API_KEY to enable TTS"
+           *     }
+           */
+          'application/problem+json': components['schemas']['ProblemDetails']
+        }
+      }
+      502: components['responses']['BadGateway']
+      503: components['responses']['ServiceUnavailable']
+    }
+  }
+  putSettingsTtsPronunciations: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        /**
+         * @example {
+         *       "rules": [
+         *         {
+         *           "string_to_replace": "Albert Heijn",
+         *           "alias": "albert hijn",
+         *           "case_sensitive": false,
+         *           "word_boundaries": true
+         *         }
+         *       ]
+         *     }
+         */
+        'application/json': components['schemas']['PronunciationRulesUpdate']
+      }
+    }
+    responses: {
+      /** @description Pronunciation rules replaced */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PronunciationRulesList']
+        }
+      }
+      401: components['responses']['Unauthorized']
+      403: components['responses']['Forbidden']
+      409: components['responses']['Conflict']
+      422: components['responses']['UnprocessableEntity']
+      429: components['responses']['TooManyRequests']
+      500: components['responses']['InternalServerError']
+      /** @description TTS is not configured on the server */
+      501: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          /**
+           * @example {
+           *       "type": "https://babbel.api/problems/tts.not_configured",
+           *       "title": "Not Implemented",
+           *       "status": 501,
+           *       "detail": "Text-to-speech is not configured",
+           *       "hint": "Set BABBEL_ELEVENLABS_API_KEY to enable TTS"
+           *     }
+           */
+          'application/problem+json': components['schemas']['ProblemDetails']
+        }
+      }
+      502: components['responses']['BadGateway']
       503: components['responses']['ServiceUnavailable']
     }
   }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,4 +1,5 @@
 export type * from './api'
+export * from './pronunciations'
 
 import type { components } from './api'
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -14,6 +14,9 @@ export type StationInput = components['schemas']['StationInput']
 export type StationVoice = components['schemas']['StationVoice']
 export type TTSSettings = components['schemas']['TTSSettings']
 export type TTSSettingsUpdate = components['schemas']['TTSSettingsUpdate']
+export type PronunciationRule = components['schemas']['PronunciationRule']
+export type PronunciationRulesList = components['schemas']['PronunciationRulesList']
+export type PronunciationRulesUpdate = components['schemas']['PronunciationRulesUpdate']
 export type Bulletin = components['schemas']['BulletinResponse']
 
 // UI uses Weekdays booleans, service converts to bitmask for API

--- a/src/lib/types/pronunciations.ts
+++ b/src/lib/types/pronunciations.ts
@@ -1,0 +1,15 @@
+import type { ProblemDetails } from '$lib/api/client'
+
+export const TTS_UNAVAILABLE_FALLBACK = 'Text-to-speech is niet geconfigureerd op de server.'
+
+export interface TTSUnavailable {
+  detail: string
+  hint?: string
+}
+
+export function createTTSUnavailable(details?: ProblemDetails): TTSUnavailable {
+  return {
+    detail: details?.detail ?? TTS_UNAVAILABLE_FALLBACK,
+    hint: details?.hint,
+  }
+}

--- a/src/routes/pronunciations/+page.svelte
+++ b/src/routes/pronunciations/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { invalidateAll } from '$app/navigation'
   import { getAuthContext } from '$lib/stores/auth.svelte'
-  import { Info } from '$lib/components/icons'
+  import { toast } from '$lib/stores/toast'
+  import { Info, RefreshCw, TriangleAlert } from '$lib/components/icons'
   import { PageHeader } from '$lib/components/ui'
   import PronunciationRulesForm from './PronunciationRulesForm.svelte'
   import type { PageProps } from './$types'
@@ -10,6 +12,26 @@
 
   const subtitle =
     'Beheer hoe ElevenLabs specifieke woorden uitspreekt voor de tekst-naar-spraak generatie.'
+  const formKey = $derived(
+    [
+      data.initial.latest_version_id,
+      data.initial.created_at,
+      data.initial.warning,
+      data.ttsUnavailable?.detail,
+      data.ttsUnavailable?.hint,
+    ]
+      .filter(Boolean)
+      .join('|')
+  )
+
+  async function reloadPronunciations(): Promise<void> {
+    try {
+      await invalidateAll()
+    } catch (err) {
+      console.error('[pronunciations] reload failed', err)
+      toast.error('Herladen mislukt')
+    }
+  }
 </script>
 
 <div class="space-y-6">
@@ -18,7 +40,41 @@
     {subtitle}
   />
 
-  {#if !auth.canEditPronunciations}
+  {#if data.loadError}
+    <div
+      class="alert alert-warning"
+      role="alert"
+    >
+      <TriangleAlert
+        aria-hidden="true"
+        class="h-5 w-5"
+      />
+      <div>
+        <h2 class="font-semibold">Uitspraakregels niet beschikbaar</h2>
+        <p class="text-sm">
+          {#if data.loadError.status}
+            HTTP {data.loadError.status}: {data.loadError.message}
+          {:else}
+            {data.loadError.message}
+          {/if}
+        </p>
+        {#if data.loadError.hint}
+          <p class="text-sm opacity-75">{data.loadError.hint}</p>
+        {/if}
+      </div>
+      <button
+        type="button"
+        class="btn btn-sm"
+        onclick={reloadPronunciations}
+      >
+        <RefreshCw
+          aria-hidden="true"
+          class="h-4 w-4"
+        />
+        Opnieuw laden
+      </button>
+    </div>
+  {:else if !auth.canEditPronunciations}
     <div
       class="alert alert-info"
       role="status"
@@ -31,11 +87,13 @@
     </div>
   {/if}
 
-  {#key JSON.stringify(data.initial)}
-    <PronunciationRulesForm
-      initial={data.initial}
-      ttsUnavailable={data.ttsUnavailable}
-      canEdit={auth.canEditPronunciations}
-    />
-  {/key}
+  {#if !data.loadError}
+    {#key formKey}
+      <PronunciationRulesForm
+        initial={data.initial}
+        ttsUnavailable={data.ttsUnavailable}
+        canEdit={auth.canEditPronunciations}
+      />
+    {/key}
+  {/if}
 </div>

--- a/src/routes/pronunciations/+page.svelte
+++ b/src/routes/pronunciations/+page.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { getAuthContext } from '$lib/stores/auth.svelte'
+  import { Info } from '$lib/components/icons'
+  import { PageHeader } from '$lib/components/ui'
+  import PronunciationRulesForm from './PronunciationRulesForm.svelte'
+  import type { PageProps } from './$types'
+
+  let { data }: PageProps = $props()
+  const auth = getAuthContext()
+
+  const subtitle =
+    'Beheer hoe ElevenLabs specifieke woorden uitspreekt voor de tekst-naar-spraak generatie.'
+</script>
+
+<div class="space-y-6">
+  <PageHeader
+    title="Uitspraakregels"
+    {subtitle}
+  />
+
+  {#if !auth.canEditPronunciations}
+    <div
+      class="alert alert-info"
+      role="status"
+    >
+      <Info
+        aria-hidden="true"
+        class="h-5 w-5"
+      />
+      <span>Alleen-lezen weergave — je hebt geen schrijfrechten.</span>
+    </div>
+  {/if}
+
+  {#key JSON.stringify(data.initial)}
+    <PronunciationRulesForm
+      initial={data.initial}
+      ttsUnavailable={data.ttsUnavailable}
+      canEdit={auth.canEditPronunciations}
+    />
+  {/key}
+</div>

--- a/src/routes/pronunciations/+page.ts
+++ b/src/routes/pronunciations/+page.ts
@@ -1,22 +1,14 @@
 import { redirect } from '@sveltejs/kit'
-import { ApiError } from '$lib/api/client'
+import { ApiError, isProblemDetails } from '$lib/api/client'
 import { settingsApi } from '$lib/api/settings'
 import { resolveInternalHref } from '$lib/utils/routes'
-import type { PronunciationRulesList } from '$lib/types'
+import { createTTSUnavailable, type PronunciationRulesList, type TTSUnavailable } from '$lib/types'
 import type { PageLoad } from './$types'
 
-export interface TTSUnavailable {
-  detail: string
+interface PronunciationsLoadError {
+  status?: number
+  message: string
   hint?: string
-}
-
-interface ProblemDetails {
-  detail?: string
-  hint?: string
-}
-
-function isProblemDetails(value: unknown): value is ProblemDetails {
-  return typeof value === 'object' && value !== null
 }
 
 const emptyRules: PronunciationRulesList = {
@@ -25,10 +17,31 @@ const emptyRules: PronunciationRulesList = {
   created_at: null,
 }
 
+function toLoadError(err: ApiError): PronunciationsLoadError {
+  const details = isProblemDetails(err.details) ? err.details : undefined
+  if (err.status === 403) {
+    return {
+      status: err.status,
+      message: details?.detail ?? 'Geen toegang tot uitspraakregels.',
+      hint: details?.hint,
+    }
+  }
+
+  return {
+    status: err.status || undefined,
+    message: details?.detail ?? details?.title ?? err.message,
+    hint: details?.hint,
+  }
+}
+
 export const load: PageLoad = async ({ fetch }) => {
   try {
     const initial = await settingsApi.getTtsPronunciations(fetch)
-    return { initial, ttsUnavailable: null as TTSUnavailable | null }
+    return {
+      initial,
+      ttsUnavailable: null as TTSUnavailable | null,
+      loadError: null as PronunciationsLoadError | null,
+    }
   } catch (err) {
     if (err instanceof ApiError && err.status === 401) {
       throw redirect(303, resolveInternalHref('/login'))
@@ -38,10 +51,16 @@ export const load: PageLoad = async ({ fetch }) => {
       const details = isProblemDetails(err.details) ? err.details : undefined
       return {
         initial: emptyRules,
-        ttsUnavailable: {
-          detail: details?.detail ?? 'Text-to-speech is niet geconfigureerd op de server.',
-          hint: details?.hint,
-        } satisfies TTSUnavailable,
+        ttsUnavailable: createTTSUnavailable(details),
+        loadError: null as PronunciationsLoadError | null,
+      }
+    }
+
+    if (err instanceof ApiError) {
+      return {
+        initial: emptyRules,
+        ttsUnavailable: null as TTSUnavailable | null,
+        loadError: toLoadError(err),
       }
     }
 

--- a/src/routes/pronunciations/+page.ts
+++ b/src/routes/pronunciations/+page.ts
@@ -1,0 +1,50 @@
+import { redirect } from '@sveltejs/kit'
+import { ApiError } from '$lib/api/client'
+import { settingsApi } from '$lib/api/settings'
+import { resolveInternalHref } from '$lib/utils/routes'
+import type { PronunciationRulesList } from '$lib/types'
+import type { PageLoad } from './$types'
+
+export interface TTSUnavailable {
+  detail: string
+  hint?: string
+}
+
+interface ProblemDetails {
+  detail?: string
+  hint?: string
+}
+
+function isProblemDetails(value: unknown): value is ProblemDetails {
+  return typeof value === 'object' && value !== null
+}
+
+const emptyRules: PronunciationRulesList = {
+  rules: [],
+  latest_version_id: null,
+  created_at: null,
+}
+
+export const load: PageLoad = async ({ fetch }) => {
+  try {
+    const initial = await settingsApi.getTtsPronunciations(fetch)
+    return { initial, ttsUnavailable: null as TTSUnavailable | null }
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 401) {
+      throw redirect(303, resolveInternalHref('/login'))
+    }
+
+    if (err instanceof ApiError && err.status === 501) {
+      const details = isProblemDetails(err.details) ? err.details : undefined
+      return {
+        initial: emptyRules,
+        ttsUnavailable: {
+          detail: details?.detail ?? 'Text-to-speech is niet geconfigureerd op de server.',
+          hint: details?.hint,
+        } satisfies TTSUnavailable,
+      }
+    }
+
+    throw err
+  }
+}

--- a/src/routes/pronunciations/PronunciationRulesForm.svelte
+++ b/src/routes/pronunciations/PronunciationRulesForm.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { tick } from 'svelte'
   import { beforeNavigate, invalidateAll } from '$app/navigation'
-  import { ApiError } from '$lib/api/client'
+  import { ApiError, isProblemDetails } from '$lib/api/client'
   import { settingsApi } from '$lib/api/settings'
   import {
+    isPronunciationRuleField,
     pronunciationRulesSchema,
-    type PronunciationRuleFormData,
+    type PronunciationRuleField,
   } from '$lib/schemas/pronunciations'
   import { toast } from '$lib/stores/toast'
   import { formatDateTime } from '$lib/utils/format'
@@ -21,12 +22,13 @@
     TriangleAlert,
     X,
   } from '$lib/components/icons'
-  import type {
-    PronunciationRule,
-    PronunciationRulesList,
-    PronunciationRulesUpdate,
+  import {
+    createTTSUnavailable,
+    type TTSUnavailable,
+    type PronunciationRule,
+    type PronunciationRulesList,
+    type PronunciationRulesUpdate,
   } from '$lib/types'
-  import type { TTSUnavailable } from './+page'
 
   interface Props {
     initial: PronunciationRulesList
@@ -37,12 +39,16 @@
   let { initial, ttsUnavailable: initialTtsUnavailable, canEdit }: Props = $props()
 
   interface DraftRow {
-    _key: number
+    readonly _key: number
     string_to_replace: string
     alias: string
     case_sensitive: boolean
     word_boundaries: boolean
   }
+
+  type RowErrors = Record<number, Partial<Record<PronunciationRuleField, string>>>
+
+  const SERVER_RULE_ERROR_RE = /^rules\[(\d+)\]\.(\w+)$/
 
   let nextKey = 1
   const makeDraft = (r: PronunciationRule): DraftRow => ({
@@ -62,18 +68,17 @@
     }))
 
   // svelte-ignore state_referenced_locally
-  const snapshot = initial.rules.map(makeDraft)
+  let snapshot = $state.raw<DraftRow[]>(initial.rules.map(makeDraft))
 
-  let rows = $state<DraftRow[]>(structuredClone($state.snapshot(snapshot)))
+  // svelte-ignore state_referenced_locally
+  let rows = $state<DraftRow[]>(structuredClone(snapshot))
   // svelte-ignore state_referenced_locally
   let warning = $state<string | undefined>(initial.warning)
   // svelte-ignore state_referenced_locally
   let createdAt = $state<string | null>(initial.created_at)
   // svelte-ignore state_referenced_locally
   let ttsUnavailable = $state<TTSUnavailable | null>(initialTtsUnavailable)
-  let rowErrors = $state<Record<number, Partial<Record<keyof PronunciationRuleFormData, string>>>>(
-    {}
-  )
+  let rowErrors = $state<RowErrors>({})
   let globalError = $state<string | null>(null)
   let submitting = $state(false)
   let search = $state('')
@@ -96,9 +101,36 @@
     createdAt ? `Laatst opgeslagen: ${formatDateTime(createdAt)}` : null
   )
 
+  function focusRowWordInput(key: number): void {
+    const inputs = [`row-${key}-word`, `m-row-${key}-word`]
+      .map(id => document.getElementById(id))
+      .filter((el): el is HTMLInputElement => el instanceof HTMLInputElement)
+
+    const input = inputs.find(el => el.getClientRects().length > 0) ?? inputs[0]
+    input?.focus()
+  }
+
+  function applyRulesList(list: PronunciationRulesList): void {
+    snapshot = list.rules.map(makeDraft)
+    rows = structuredClone(snapshot)
+    warning = list.warning
+    createdAt = list.created_at
+    rowErrors = {}
+    globalError = null
+    search = ''
+  }
+
+  function resetToSnapshot(): void {
+    rows = structuredClone(snapshot)
+    rowErrors = {}
+    globalError = null
+    search = ''
+  }
+
   async function handleAddRow(): Promise<void> {
     if (!editable) return
     const key = nextKey++
+    search = ''
     rows = [
       ...rows,
       {
@@ -110,7 +142,7 @@
       },
     ]
     await tick()
-    document.getElementById(`row-${key}-word`)?.focus()
+    focusRowWordInput(key)
   }
 
   function handleRemoveRow(key: number): void {
@@ -122,7 +154,7 @@
     }
   }
 
-  function clearRowError(key: number, field: keyof PronunciationRuleFormData): void {
+  function clearRowError(key: number, field: PronunciationRuleField): void {
     const current = rowErrors[key]
     if (!current?.[field]) return
     const { [field]: _removed, ...rest } = current
@@ -142,20 +174,24 @@
     const payload = toPayload(rows)
     const parsed = pronunciationRulesSchema.safeParse({ rules: payload })
     if (!parsed.success) {
-      const nextErrors: typeof rowErrors = {}
+      const nextErrors: RowErrors = {}
+      let hasRowErrors = false
       for (const issue of parsed.error.issues) {
         if (issue.path[0] === 'rules' && typeof issue.path[1] === 'number') {
           const row = rows[issue.path[1]]
-          const field = issue.path[2] as keyof PronunciationRuleFormData
-          if (row) {
+          const field = issue.path[2]
+          if (row && typeof field === 'string' && isPronunciationRuleField(field)) {
             nextErrors[row._key] = { ...nextErrors[row._key], [field]: issue.message }
+            hasRowErrors = true
+          } else {
+            globalError = issue.message
           }
         } else {
           globalError = issue.message
         }
       }
       rowErrors = nextErrors
-      search = ''
+      if (hasRowErrors) search = ''
       toast.error('Controleer de fouten in het formulier')
       return
     }
@@ -168,11 +204,23 @@
 
     submitting = true
     try {
-      await settingsApi.updateTtsPronunciations({ rules: payload })
+      let saved: PronunciationRulesList
+      try {
+        saved = await settingsApi.updateTtsPronunciations({ rules: payload })
+      } catch (err) {
+        handleSaveError(err)
+        return
+      }
+
+      applyRulesList(saved)
       toast.success('Uitspraakregels opgeslagen')
-      await invalidateAll()
-    } catch (err) {
-      handleSaveError(err)
+
+      try {
+        await invalidateAll()
+      } catch (err) {
+        console.error('[pronunciations] refresh after save failed', err)
+        toast.warning('Opgeslagen, maar vernieuwen mislukt')
+      }
     } finally {
       submitting = false
     }
@@ -180,37 +228,35 @@
 
   function handleSaveError(err: unknown): void {
     if (!(err instanceof ApiError)) {
+      console.error('[pronunciations] unexpected save error', err)
       toast.error('Opslaan mislukt')
       return
     }
 
-    const details = err.details as
-      | {
-          code?: string
-          type?: string
-          detail?: string
-          hint?: string
-          errors?: Array<{ field: string; message: string }>
-        }
-      | undefined
+    const details = isProblemDetails(err.details) ? err.details : undefined
 
     if (err.status === 422 && details?.errors?.length) {
-      const re = /^rules\[(\d+)\]\.(\w+)$/
-      const nextErrors: typeof rowErrors = {}
+      const nextErrors: RowErrors = {}
       const globalMessages: string[] = []
       for (const e of details.errors) {
-        const m = re.exec(e.field)
+        const message = e.message ?? details.detail ?? 'De server heeft een veldfout teruggegeven'
+        if (!e.field) {
+          globalMessages.push(message)
+          continue
+        }
+
+        const m = SERVER_RULE_ERROR_RE.exec(e.field)
         if (!m) {
-          globalMessages.push(e.message)
+          globalMessages.push(message)
           continue
         }
         const idx = Number(m[1])
-        const field = m[2] as keyof PronunciationRuleFormData
+        const field = m[2]
         const row = rows[idx]
-        if (row) {
-          nextErrors[row._key] = { ...nextErrors[row._key], [field]: e.message }
+        if (row && isPronunciationRuleField(field)) {
+          nextErrors[row._key] = { ...nextErrors[row._key], [field]: message }
         } else {
-          globalMessages.push(e.message)
+          globalMessages.push(message)
         }
       }
       rowErrors = nextErrors
@@ -237,10 +283,7 @@
       return
     }
     if (err.status === 501) {
-      ttsUnavailable = {
-        detail: details?.detail ?? 'Text-to-speech is niet geconfigureerd op de server.',
-        hint: details?.hint,
-      }
+      ttsUnavailable = createTTSUnavailable(details)
       globalError = ttsUnavailable.detail
       toast.error('TTS niet geconfigureerd')
       return
@@ -260,15 +303,20 @@
   function handleCancel(): void {
     if (!isDirty) return
     if (!confirm('Weet je zeker dat je je wijzigingen wilt annuleren?')) return
-    rows = structuredClone($state.snapshot(snapshot))
-    rowErrors = {}
-    globalError = null
-    search = ''
+    resetToSnapshot()
   }
 
   async function handleReload(): Promise<void> {
     if (isDirty && !confirm('Je hebt niet-opgeslagen wijzigingen. Herladen?')) return
-    await invalidateAll()
+    try {
+      await invalidateAll()
+      await tick()
+      applyRulesList(initial)
+      ttsUnavailable = initialTtsUnavailable
+    } catch (err) {
+      console.error('[pronunciations] reload failed', err)
+      toast.error('Herladen mislukt')
+    }
   }
 
   beforeNavigate(({ cancel }) => {
@@ -277,16 +325,14 @@
     }
   })
 
-  $effect(() => {
-    const handler = (event: BeforeUnloadEvent): void => {
-      if (!isDirty) return
-      event.preventDefault()
-      event.returnValue = ''
-    }
-    window.addEventListener('beforeunload', handler)
-    return () => window.removeEventListener('beforeunload', handler)
-  })
+  function handleBeforeUnload(event: BeforeUnloadEvent): void {
+    if (!isDirty) return
+    event.preventDefault()
+    event.returnValue = ''
+  }
 </script>
+
+<svelte:window onbeforeunload={handleBeforeUnload} />
 
 <div class="space-y-4">
   {#if ttsUnavailable}
@@ -338,7 +384,6 @@
 
   <div class="card bg-base-100">
     <div class="card-body gap-4">
-      <!-- Toolbar -->
       <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <label class="input max-w-md">
           <Search
@@ -403,7 +448,6 @@
           Geen regels gevonden voor "{search}".
         </div>
       {:else}
-        <!-- Desktop: table -->
         <div class="hidden overflow-x-auto md:block">
           <table class="table">
             <thead>
@@ -430,7 +474,7 @@
               </tr>
             </thead>
             <tbody>
-              {#each filteredRows as row (row._key)}
+              {#each filteredRows as row, index (row._key)}
                 {@const errs = rowErrors[row._key]}
                 <tr>
                   <td class="align-top">
@@ -440,7 +484,7 @@
                       class={['input w-full', errs?.string_to_replace && 'input-error']}
                       bind:value={row.string_to_replace}
                       oninput={() => clearRowError(row._key, 'string_to_replace')}
-                      aria-label="Woord"
+                      aria-label="Woord regel {index + 1}"
                       disabled={!editable}
                     />
                     {#if errs?.string_to_replace}
@@ -454,7 +498,7 @@
                       class={['input w-full', errs?.alias && 'input-error']}
                       bind:value={row.alias}
                       oninput={() => clearRowError(row._key, 'alias')}
-                      aria-label="Uitspraak"
+                      aria-label="Uitspraak regel {index + 1}"
                       disabled={!editable}
                     />
                     {#if errs?.alias}
@@ -466,7 +510,7 @@
                       type="checkbox"
                       class="checkbox"
                       bind:checked={row.case_sensitive}
-                      aria-label="Hoofdlettergevoelig"
+                      aria-label="Hoofdlettergevoelig regel {index + 1}"
                       disabled={!editable}
                     />
                   </td>
@@ -475,7 +519,7 @@
                       type="checkbox"
                       class="checkbox"
                       bind:checked={row.word_boundaries}
-                      aria-label="Woordgrenzen"
+                      aria-label="Woordgrenzen regel {index + 1}"
                       disabled={!editable}
                     />
                   </td>
@@ -485,7 +529,7 @@
                         type="button"
                         class="btn btn-square btn-ghost btn-sm"
                         onclick={() => handleRemoveRow(row._key)}
-                        aria-label="Regel verwijderen"
+                        aria-label="Regel {index + 1} verwijderen"
                       >
                         <Trash2
                           aria-hidden="true"
@@ -500,9 +544,8 @@
           </table>
         </div>
 
-        <!-- Mobile: stacked cards -->
         <div class="space-y-3 md:hidden">
-          {#each filteredRows as row (row._key)}
+          {#each filteredRows as row, index (row._key)}
             {@const errs = rowErrors[row._key]}
             <div class="rounded-lg border border-base-300 p-4">
               <fieldset class="fieldset">
@@ -518,6 +561,7 @@
                   class={['input w-full', errs?.string_to_replace && 'input-error']}
                   bind:value={row.string_to_replace}
                   oninput={() => clearRowError(row._key, 'string_to_replace')}
+                  aria-label="Woord regel {index + 1}"
                   disabled={!editable}
                 />
                 {#if errs?.string_to_replace}
@@ -538,6 +582,7 @@
                   class={['input w-full', errs?.alias && 'input-error']}
                   bind:value={row.alias}
                   oninput={() => clearRowError(row._key, 'alias')}
+                  aria-label="Uitspraak regel {index + 1}"
                   disabled={!editable}
                 />
                 {#if errs?.alias}
@@ -551,6 +596,7 @@
                     type="checkbox"
                     class="checkbox checkbox-sm"
                     bind:checked={row.case_sensitive}
+                    aria-label="Hoofdlettergevoelig regel {index + 1}"
                     disabled={!editable}
                   />
                   <span class="text-sm">Hoofdlettergevoelig</span>
@@ -560,6 +606,7 @@
                     type="checkbox"
                     class="checkbox checkbox-sm"
                     bind:checked={row.word_boundaries}
+                    aria-label="Woordgrenzen regel {index + 1}"
                     disabled={!editable}
                   />
                   <span class="text-sm">Woordgrenzen</span>
@@ -572,6 +619,7 @@
                     type="button"
                     class="btn btn-ghost btn-sm"
                     onclick={() => handleRemoveRow(row._key)}
+                    aria-label="Regel {index + 1} verwijderen"
                   >
                     <Trash2
                       aria-hidden="true"

--- a/src/routes/pronunciations/PronunciationRulesForm.svelte
+++ b/src/routes/pronunciations/PronunciationRulesForm.svelte
@@ -1,0 +1,626 @@
+<script lang="ts">
+  import { tick } from 'svelte'
+  import { beforeNavigate, invalidateAll } from '$app/navigation'
+  import { ApiError } from '$lib/api/client'
+  import { settingsApi } from '$lib/api/settings'
+  import {
+    pronunciationRulesSchema,
+    type PronunciationRuleFormData,
+  } from '$lib/schemas/pronunciations'
+  import { toast } from '$lib/stores/toast'
+  import { formatDateTime } from '$lib/utils/format'
+  import { EmptyState } from '$lib/components/ui'
+  import {
+    BookOpen,
+    Check,
+    Info,
+    Plus,
+    RefreshCw,
+    Search,
+    Trash2,
+    TriangleAlert,
+    X,
+  } from '$lib/components/icons'
+  import type {
+    PronunciationRule,
+    PronunciationRulesList,
+    PronunciationRulesUpdate,
+  } from '$lib/types'
+  import type { TTSUnavailable } from './+page'
+
+  interface Props {
+    initial: PronunciationRulesList
+    ttsUnavailable: TTSUnavailable | null
+    canEdit: boolean
+  }
+
+  let { initial, ttsUnavailable: initialTtsUnavailable, canEdit }: Props = $props()
+
+  interface DraftRow {
+    _key: number
+    string_to_replace: string
+    alias: string
+    case_sensitive: boolean
+    word_boundaries: boolean
+  }
+
+  let nextKey = 1
+  const makeDraft = (r: PronunciationRule): DraftRow => ({
+    _key: nextKey++,
+    string_to_replace: r.string_to_replace ?? '',
+    alias: r.alias ?? '',
+    case_sensitive: r.case_sensitive ?? true,
+    word_boundaries: r.word_boundaries ?? true,
+  })
+
+  const toPayload = (drafts: DraftRow[]): PronunciationRulesUpdate['rules'] =>
+    drafts.map(r => ({
+      string_to_replace: r.string_to_replace.trim(),
+      alias: r.alias.trim(),
+      case_sensitive: r.case_sensitive,
+      word_boundaries: r.word_boundaries,
+    }))
+
+  // svelte-ignore state_referenced_locally
+  const snapshot = initial.rules.map(makeDraft)
+
+  let rows = $state<DraftRow[]>(structuredClone($state.snapshot(snapshot)))
+  // svelte-ignore state_referenced_locally
+  let warning = $state<string | undefined>(initial.warning)
+  // svelte-ignore state_referenced_locally
+  let createdAt = $state<string | null>(initial.created_at)
+  // svelte-ignore state_referenced_locally
+  let ttsUnavailable = $state<TTSUnavailable | null>(initialTtsUnavailable)
+  let rowErrors = $state<Record<number, Partial<Record<keyof PronunciationRuleFormData, string>>>>(
+    {}
+  )
+  let globalError = $state<string | null>(null)
+  let submitting = $state(false)
+  let search = $state('')
+
+  const editable = $derived(canEdit && !ttsUnavailable)
+
+  const isDirty = $derived(JSON.stringify(toPayload(rows)) !== JSON.stringify(toPayload(snapshot)))
+  const saveDisabled = $derived(!editable || !isDirty || submitting)
+
+  const filteredRows = $derived.by(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return rows
+    return rows.filter(
+      r => r.string_to_replace.toLowerCase().includes(q) || r.alias.toLowerCase().includes(q)
+    )
+  })
+
+  const countLabel = $derived(`${rows.length} ${rows.length === 1 ? 'regel' : 'regels'}`)
+  const savedAtLabel = $derived(
+    createdAt ? `Laatst opgeslagen: ${formatDateTime(createdAt)}` : null
+  )
+
+  async function handleAddRow(): Promise<void> {
+    if (!editable) return
+    const key = nextKey++
+    rows = [
+      ...rows,
+      {
+        _key: key,
+        string_to_replace: '',
+        alias: '',
+        case_sensitive: true,
+        word_boundaries: true,
+      },
+    ]
+    await tick()
+    document.getElementById(`row-${key}-word`)?.focus()
+  }
+
+  function handleRemoveRow(key: number): void {
+    if (!editable) return
+    rows = rows.filter(r => r._key !== key)
+    if (rowErrors[key]) {
+      const { [key]: _removed, ...rest } = rowErrors
+      rowErrors = rest
+    }
+  }
+
+  function clearRowError(key: number, field: keyof PronunciationRuleFormData): void {
+    const current = rowErrors[key]
+    if (!current?.[field]) return
+    const { [field]: _removed, ...rest } = current
+    if (Object.keys(rest).length === 0) {
+      const { [key]: _gone, ...others } = rowErrors
+      rowErrors = others
+    } else {
+      rowErrors = { ...rowErrors, [key]: rest }
+    }
+  }
+
+  async function handleSave(): Promise<void> {
+    if (submitting || !editable) return
+    rowErrors = {}
+    globalError = null
+
+    const payload = toPayload(rows)
+    const parsed = pronunciationRulesSchema.safeParse({ rules: payload })
+    if (!parsed.success) {
+      const nextErrors: typeof rowErrors = {}
+      for (const issue of parsed.error.issues) {
+        if (issue.path[0] === 'rules' && typeof issue.path[1] === 'number') {
+          const row = rows[issue.path[1]]
+          const field = issue.path[2] as keyof PronunciationRuleFormData
+          if (row) {
+            nextErrors[row._key] = { ...nextErrors[row._key], [field]: issue.message }
+          }
+        } else {
+          globalError = issue.message
+        }
+      }
+      rowErrors = nextErrors
+      search = ''
+      toast.error('Controleer de fouten in het formulier')
+      return
+    }
+
+    if (payload.length === 0 && snapshot.length > 0) {
+      if (!confirm('Weet je zeker dat je ALLE uitspraakregels wilt verwijderen?')) {
+        return
+      }
+    }
+
+    submitting = true
+    try {
+      await settingsApi.updateTtsPronunciations({ rules: payload })
+      toast.success('Uitspraakregels opgeslagen')
+      await invalidateAll()
+    } catch (err) {
+      handleSaveError(err)
+    } finally {
+      submitting = false
+    }
+  }
+
+  function handleSaveError(err: unknown): void {
+    if (!(err instanceof ApiError)) {
+      toast.error('Opslaan mislukt')
+      return
+    }
+
+    const details = err.details as
+      | {
+          code?: string
+          type?: string
+          detail?: string
+          hint?: string
+          errors?: Array<{ field: string; message: string }>
+        }
+      | undefined
+
+    if (err.status === 422 && details?.errors?.length) {
+      const re = /^rules\[(\d+)\]\.(\w+)$/
+      const nextErrors: typeof rowErrors = {}
+      const globalMessages: string[] = []
+      for (const e of details.errors) {
+        const m = re.exec(e.field)
+        if (!m) {
+          globalMessages.push(e.message)
+          continue
+        }
+        const idx = Number(m[1])
+        const field = m[2] as keyof PronunciationRuleFormData
+        const row = rows[idx]
+        if (row) {
+          nextErrors[row._key] = { ...nextErrors[row._key], [field]: e.message }
+        } else {
+          globalMessages.push(e.message)
+        }
+      }
+      rowErrors = nextErrors
+      if (globalMessages.length > 0) {
+        globalError = globalMessages.join(' ')
+      }
+      search = ''
+      toast.error(
+        globalMessages.length > 0
+          ? 'De server heeft fouten gevonden'
+          : 'De server heeft fouten gevonden — zie de rijen.'
+      )
+      return
+    }
+
+    if (err.status === 409) {
+      globalError =
+        'De koppeling met het uitspraakwoordenboek is intussen gewijzigd. Herlaad de pagina om de nieuwste versie te zien.'
+      toast.error('Conflict — herlaad de pagina')
+      return
+    }
+    if (err.status === 403) {
+      toast.error('Geen rechten om uitspraakregels te wijzigen')
+      return
+    }
+    if (err.status === 501) {
+      ttsUnavailable = {
+        detail: details?.detail ?? 'Text-to-speech is niet geconfigureerd op de server.',
+        hint: details?.hint,
+      }
+      globalError = ttsUnavailable.detail
+      toast.error('TTS niet geconfigureerd')
+      return
+    }
+    if (err.status === 502 || err.status === 503) {
+      globalError = details?.hint ?? details?.detail ?? 'ElevenLabs niet bereikbaar'
+      toast.error(globalError)
+      return
+    }
+    if (err.status === 429) {
+      toast.error('Te veel verzoeken — probeer het later opnieuw')
+      return
+    }
+    toast.error(details?.detail ?? err.message ?? 'Opslaan mislukt')
+  }
+
+  function handleCancel(): void {
+    if (!isDirty) return
+    if (!confirm('Weet je zeker dat je je wijzigingen wilt annuleren?')) return
+    rows = structuredClone($state.snapshot(snapshot))
+    rowErrors = {}
+    globalError = null
+    search = ''
+  }
+
+  async function handleReload(): Promise<void> {
+    if (isDirty && !confirm('Je hebt niet-opgeslagen wijzigingen. Herladen?')) return
+    await invalidateAll()
+  }
+
+  beforeNavigate(({ cancel }) => {
+    if (isDirty && !confirm('Je hebt niet-opgeslagen wijzigingen. Pagina verlaten?')) {
+      cancel()
+    }
+  })
+
+  $effect(() => {
+    const handler = (event: BeforeUnloadEvent): void => {
+      if (!isDirty) return
+      event.preventDefault()
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  })
+</script>
+
+<div class="space-y-4">
+  {#if ttsUnavailable}
+    <div
+      class="alert alert-info"
+      role="status"
+    >
+      <Info
+        aria-hidden="true"
+        class="h-5 w-5"
+      />
+      <div>
+        <div class="font-medium">Text-to-speech is niet geconfigureerd</div>
+        <div class="text-sm">
+          {ttsUnavailable.detail}
+          {#if ttsUnavailable.hint}
+            <div class="opacity-80">{ttsUnavailable.hint}</div>
+          {/if}
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  {#if warning}
+    <div
+      class="alert alert-warning"
+      role="alert"
+    >
+      <TriangleAlert
+        aria-hidden="true"
+        class="h-5 w-5"
+      />
+      <span>{warning}</span>
+    </div>
+  {/if}
+
+  {#if globalError}
+    <div
+      class="alert alert-error"
+      role="alert"
+    >
+      <TriangleAlert
+        aria-hidden="true"
+        class="h-5 w-5"
+      />
+      <span>{globalError}</span>
+    </div>
+  {/if}
+
+  <div class="card bg-base-100">
+    <div class="card-body gap-4">
+      <!-- Toolbar -->
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <label class="input max-w-md">
+          <Search
+            aria-hidden="true"
+            class="h-4 w-4 opacity-60"
+          />
+          <input
+            type="text"
+            placeholder="Zoek in woord of uitspraak…"
+            aria-label="Zoek in uitspraakregels"
+            bind:value={search}
+          />
+        </label>
+        <div class="flex flex-wrap items-center gap-3 text-sm text-base-content/60">
+          <span>
+            {#if search.trim()}
+              {filteredRows.length} van {rows.length} getoond
+            {:else}
+              {countLabel}
+            {/if}
+          </span>
+          {#if savedAtLabel}
+            <span class="hidden sm:inline">·</span>
+            <span>{savedAtLabel}</span>
+          {/if}
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm"
+            onclick={handleReload}
+            aria-label="Herlaad uitspraakregels"
+          >
+            <RefreshCw
+              aria-hidden="true"
+              class="h-4 w-4"
+            />
+            Herlaad
+          </button>
+          {#if editable}
+            <button
+              type="button"
+              class="btn btn-primary btn-sm"
+              onclick={handleAddRow}
+            >
+              <Plus
+                aria-hidden="true"
+                class="h-4 w-4"
+              />
+              Nieuwe regel
+            </button>
+          {/if}
+        </div>
+      </div>
+
+      {#if rows.length === 0}
+        <EmptyState
+          icon={BookOpen}
+          title="Nog geen uitspraakregels"
+          description="Voeg een regel toe om woorden anders uit te laten spreken."
+        />
+      {:else if filteredRows.length === 0}
+        <div class="py-10 text-center text-base-content/60">
+          Geen regels gevonden voor "{search}".
+        </div>
+      {:else}
+        <!-- Desktop: table -->
+        <div class="hidden overflow-x-auto md:block">
+          <table class="table">
+            <thead>
+              <tr>
+                <th class="w-2/5">Woord</th>
+                <th class="w-2/5">Uitspraak</th>
+                <th class="w-24 text-center">
+                  <span
+                    class="tooltip tooltip-left"
+                    data-tip="Aan: alleen exacte hoofdletters/kleine letters matchen. Uit: hoofdletterongevoelig matchen."
+                  >
+                    Hfd
+                  </span>
+                </th>
+                <th class="w-24 text-center">
+                  <span
+                    class="tooltip tooltip-left"
+                    data-tip="Aan: alleen hele woorden matchen. Uit: ook midden in een woord matchen (bv. 'art' in 'kunst')."
+                  >
+                    Grens
+                  </span>
+                </th>
+                <th class="w-16 text-right">Acties</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each filteredRows as row (row._key)}
+                {@const errs = rowErrors[row._key]}
+                <tr>
+                  <td class="align-top">
+                    <input
+                      id="row-{row._key}-word"
+                      type="text"
+                      class={['input w-full', errs?.string_to_replace && 'input-error']}
+                      bind:value={row.string_to_replace}
+                      oninput={() => clearRowError(row._key, 'string_to_replace')}
+                      aria-label="Woord"
+                      disabled={!editable}
+                    />
+                    {#if errs?.string_to_replace}
+                      <p class="label text-error">{errs.string_to_replace}</p>
+                    {/if}
+                  </td>
+                  <td class="align-top">
+                    <input
+                      id="row-{row._key}-alias"
+                      type="text"
+                      class={['input w-full', errs?.alias && 'input-error']}
+                      bind:value={row.alias}
+                      oninput={() => clearRowError(row._key, 'alias')}
+                      aria-label="Uitspraak"
+                      disabled={!editable}
+                    />
+                    {#if errs?.alias}
+                      <p class="label text-error">{errs.alias}</p>
+                    {/if}
+                  </td>
+                  <td class="text-center align-top">
+                    <input
+                      type="checkbox"
+                      class="checkbox"
+                      bind:checked={row.case_sensitive}
+                      aria-label="Hoofdlettergevoelig"
+                      disabled={!editable}
+                    />
+                  </td>
+                  <td class="text-center align-top">
+                    <input
+                      type="checkbox"
+                      class="checkbox"
+                      bind:checked={row.word_boundaries}
+                      aria-label="Woordgrenzen"
+                      disabled={!editable}
+                    />
+                  </td>
+                  <td class="text-right align-top">
+                    {#if editable}
+                      <button
+                        type="button"
+                        class="btn btn-square btn-ghost btn-sm"
+                        onclick={() => handleRemoveRow(row._key)}
+                        aria-label="Regel verwijderen"
+                      >
+                        <Trash2
+                          aria-hidden="true"
+                          class="h-4 w-4"
+                        />
+                      </button>
+                    {/if}
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mobile: stacked cards -->
+        <div class="space-y-3 md:hidden">
+          {#each filteredRows as row (row._key)}
+            {@const errs = rowErrors[row._key]}
+            <div class="rounded-lg border border-base-300 p-4">
+              <fieldset class="fieldset">
+                <label
+                  for="m-row-{row._key}-word"
+                  class="fieldset-legend"
+                >
+                  Woord
+                </label>
+                <input
+                  id="m-row-{row._key}-word"
+                  type="text"
+                  class={['input w-full', errs?.string_to_replace && 'input-error']}
+                  bind:value={row.string_to_replace}
+                  oninput={() => clearRowError(row._key, 'string_to_replace')}
+                  disabled={!editable}
+                />
+                {#if errs?.string_to_replace}
+                  <p class="label text-error">{errs.string_to_replace}</p>
+                {/if}
+              </fieldset>
+
+              <fieldset class="fieldset">
+                <label
+                  for="m-row-{row._key}-alias"
+                  class="fieldset-legend"
+                >
+                  Uitspraak
+                </label>
+                <input
+                  id="m-row-{row._key}-alias"
+                  type="text"
+                  class={['input w-full', errs?.alias && 'input-error']}
+                  bind:value={row.alias}
+                  oninput={() => clearRowError(row._key, 'alias')}
+                  disabled={!editable}
+                />
+                {#if errs?.alias}
+                  <p class="label text-error">{errs.alias}</p>
+                {/if}
+              </fieldset>
+
+              <div class="mt-3 flex flex-wrap gap-4">
+                <label class="flex cursor-pointer items-center gap-2">
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-sm"
+                    bind:checked={row.case_sensitive}
+                    disabled={!editable}
+                  />
+                  <span class="text-sm">Hoofdlettergevoelig</span>
+                </label>
+                <label class="flex cursor-pointer items-center gap-2">
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-sm"
+                    bind:checked={row.word_boundaries}
+                    disabled={!editable}
+                  />
+                  <span class="text-sm">Woordgrenzen</span>
+                </label>
+              </div>
+
+              {#if editable}
+                <div class="mt-3 flex justify-end">
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-sm"
+                    onclick={() => handleRemoveRow(row._key)}
+                  >
+                    <Trash2
+                      aria-hidden="true"
+                      class="h-4 w-4"
+                    />
+                    Verwijder
+                  </button>
+                </div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      {#if editable}
+        <div class="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            class="btn btn-ghost"
+            onclick={handleCancel}
+            disabled={!isDirty || submitting}
+          >
+            <X
+              aria-hidden="true"
+              class="h-5 w-5"
+            />
+            Annuleren
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            onclick={handleSave}
+            disabled={saveDisabled}
+          >
+            {#if submitting}
+              <span
+                class="loading loading-sm loading-spinner"
+                aria-hidden="true"
+              ></span>
+            {:else}
+              <Check
+                aria-hidden="true"
+                class="h-5 w-5"
+              />
+            {/if}
+            Opslaan
+          </button>
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/src/routes/pronunciations/PronunciationRulesForm.svelte
+++ b/src/routes/pronunciations/PronunciationRulesForm.svelte
@@ -67,6 +67,20 @@
       word_boundaries: r.word_boundaries,
     }))
 
+  function draftsEqual(a: DraftRow[], b: DraftRow[]): boolean {
+    if (a.length !== b.length) return false
+
+    return a.every((row, index) => {
+      const other = b[index]
+      return (
+        row.string_to_replace.trim() === other.string_to_replace.trim() &&
+        row.alias.trim() === other.alias.trim() &&
+        row.case_sensitive === other.case_sensitive &&
+        row.word_boundaries === other.word_boundaries
+      )
+    })
+  }
+
   // svelte-ignore state_referenced_locally
   let snapshot = $state.raw<DraftRow[]>(initial.rules.map(makeDraft))
 
@@ -85,7 +99,7 @@
 
   const editable = $derived(canEdit && !ttsUnavailable)
 
-  const isDirty = $derived(JSON.stringify(toPayload(rows)) !== JSON.stringify(toPayload(snapshot)))
+  const isDirty = $derived(!draftsEqual(rows, snapshot))
   const saveDisabled = $derived(!editable || !isDirty || submitting)
 
   const filteredRows = $derived.by(() => {
@@ -237,17 +251,17 @@
 
     if (err.status === 422 && details?.errors?.length) {
       const nextErrors: RowErrors = {}
-      const globalMessages: string[] = []
+      const globalMessages = new Set<string>()
       for (const e of details.errors) {
         const message = e.message ?? details.detail ?? 'De server heeft een veldfout teruggegeven'
         if (!e.field) {
-          globalMessages.push(message)
+          globalMessages.add(message)
           continue
         }
 
         const m = SERVER_RULE_ERROR_RE.exec(e.field)
         if (!m) {
-          globalMessages.push(message)
+          globalMessages.add(message)
           continue
         }
         const idx = Number(m[1])
@@ -256,16 +270,16 @@
         if (row && isPronunciationRuleField(field)) {
           nextErrors[row._key] = { ...nextErrors[row._key], [field]: message }
         } else {
-          globalMessages.push(message)
+          globalMessages.add(message)
         }
       }
       rowErrors = nextErrors
-      if (globalMessages.length > 0) {
-        globalError = globalMessages.join(' ')
+      if (globalMessages.size > 0) {
+        globalError = [...globalMessages].join(' ')
       }
       search = ''
       toast.error(
-        globalMessages.length > 0
+        globalMessages.size > 0
           ? 'De server heeft fouten gevonden'
           : 'De server heeft fouten gevonden — zie de rijen.'
       )

--- a/src/routes/settings/ai/+page.ts
+++ b/src/routes/settings/ai/+page.ts
@@ -1,6 +1,6 @@
 import type { PageLoad } from './$types'
 import { redirect } from '@sveltejs/kit'
-import { ApiError } from '$lib/api/client'
+import { ApiError, isProblemDetails } from '$lib/api/client'
 import { settingsApi } from '$lib/api/settings'
 import { resolveInternalHref } from '$lib/utils/routes'
 
@@ -8,16 +8,6 @@ interface SettingsLoadError {
   status?: number
   message: string
   hint?: string
-}
-
-interface ProblemDetails {
-  detail?: string
-  title?: string
-  hint?: string
-}
-
-function isProblemDetails(value: unknown): value is ProblemDetails {
-  return typeof value === 'object' && value !== null
 }
 
 function toSettingsLoadError(err: unknown): SettingsLoadError {


### PR DESCRIPTION
## Summary

Adds the **Uitspraakregels** page at `/pronunciations` so editors and admins can manage the Babbel-managed ElevenLabs pronunciation dictionary directly from the UI. Replaces the complete rule set on each save (single `PUT /settings/tts/pronunciations`) so server-side ordering and ElevenLabs `version_id` remain consistent.

- New sidebar section **AI** between Menu and Admin, visible to anyone with edit rights (`auth.canEditPronunciations`). AI-instellingen stays under Admin since it owns the API key.
- Desktop table + mobile card layouts share the same row state and validation.
- Per-row inline validation (zod `superRefine` catches duplicate keys); 422 field errors `rules[N].field` map back to the originating row.
- 501 (TTS not configured) surfaces as an inline alert that disables editing without breaking the page; 409 conflicts prompt a reload; 502/503/429 surface server hints.
- Dirty-state tracking with `beforeNavigate` + `beforeunload` guards against losing unsaved edits.

## Files

- `src/lib/api/settings.ts` — extends `settingsApi` with `getTtsPronunciations` / `updateTtsPronunciations`
- `src/lib/schemas/pronunciations.ts` — zod schema + duplicate-key `superRefine`
- `src/lib/types/api.ts` + `index.ts` — regenerated from `openapi.yaml`, exports `PronunciationRule(s)Update`
- `src/lib/stores/auth.svelte.ts` — adds `canEditPronunciations` derived (admin + editor)
- `src/lib/components/icons.ts` — adds `BookOpen`
- `src/lib/components/Layout.svelte` — new AI nav section
- `src/routes/pronunciations/+page.{ts,svelte}` + `PronunciationRulesForm.svelte` — page + editor decomposed for parent-key reset (matches `TTSSettingsForm` pattern)

## Compliance

All new markup uses daisyUI v5 + Svelte 5 idioms — no `input-bordered`, no `form-control`, no `label-text`. Uses `fieldset`/`fieldset-legend` for mobile cards, `class={['...', cond && '...']}` array-class syntax, `resolveInternalHref` (not needed in this branch since no internal `<a>` was added, but ready for it), context-injected auth via `getAuthContext()`.

## Test plan

- [ ] Page loads at `/pronunciations` for authenticated users; redirects to `/login` for unauthenticated
- [ ] Viewer role sees the data but cannot edit (read-only banner + disabled inputs)
- [ ] Editor/admin can add, edit, delete rows; Save persists via PUT
- [ ] Duplicate `string_to_replace` shows inline error (no server roundtrip needed)
- [ ] Empty save with previously-saved rules prompts confirmation before clearing
- [ ] 501 from API renders the "TTS niet geconfigureerd" alert; editing disabled
- [ ] Search filter narrows visible rows; count shows "N van M getoond"
- [ ] Reload button discards local edits after confirmation
- [ ] Leaving the page with unsaved edits prompts confirmation