### PR TITLE
refactor: move TTS settings into the AI menu as Spraakmodel

### DIFF
--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -39,9 +39,7 @@
     { path: '/settings/ai', label: 'Spraakmodel', icon: Sparkles },
   ]
 
-  const adminNavItems: NavItem[] = [
-    { path: '/users', label: 'Gebruikers', icon: Users },
-  ]
+  const adminNavItems: NavItem[] = [{ path: '/users', label: 'Gebruikers', icon: Users }]
 
   function isActive(path: string): boolean {
     return page.url.pathname === path || page.url.pathname.startsWith(`${path}/`)

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -36,11 +36,11 @@
 
   const aiNavItems: NavItem[] = [
     { path: '/pronunciations', label: 'Uitspraakregels', icon: BookOpen },
+    { path: '/settings/ai', label: 'Spraakmodel', icon: Sparkles },
   ]
 
   const adminNavItems: NavItem[] = [
     { path: '/users', label: 'Gebruikers', icon: Users },
-    { path: '/settings/ai', label: 'AI-instellingen', icon: Sparkles },
   ]
 
   function isActive(path: string): boolean {
@@ -145,7 +145,7 @@
             </li>
           {/each}
 
-          {#if auth.canViewPronunciations}
+          {#if auth.canViewPronunciations || auth.canViewTtsSettings}
             <li class="mt-4 menu-title tracking-widest uppercase">AI</li>
             {#each aiNavItems as item (item.path)}
               {@const Icon = item.icon}

--- a/src/lib/stores/auth.svelte.ts
+++ b/src/lib/stores/auth.svelte.ts
@@ -14,6 +14,8 @@ export class AuthStore {
   isAdmin = $derived(this.user?.role === 'admin')
   canViewPronunciations = $derived(!!this.user)
   canEditPronunciations = $derived(this.user?.role === 'admin' || this.user?.role === 'editor')
+  canViewTtsSettings = $derived(!!this.user)
+  canEditTtsSettings = $derived(this.user?.role === 'admin')
 
   private checkPromise: Promise<boolean> | null = null
 

--- a/src/routes/settings/ai/+page.svelte
+++ b/src/routes/settings/ai/+page.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { invalidateAll } from '$app/navigation'
-  import { RefreshCw, TriangleAlert } from '$lib/components/icons'
+  import { getAuthContext } from '$lib/stores/auth.svelte'
+  import { Info, RefreshCw, TriangleAlert } from '$lib/components/icons'
   import { PageHeader } from '$lib/components/ui'
   import TTSSettingsForm from './TTSSettingsForm.svelte'
   import type { PageProps } from './$types'
 
   let { data }: PageProps = $props()
+  const auth = getAuthContext()
 
   async function reloadSettings(): Promise<void> {
     await invalidateAll()
@@ -14,7 +16,7 @@
 
 <div class="space-y-6">
   <PageHeader
-    title="AI-instellingen"
+    title="Spraakmodel"
     subtitle="Globale ElevenLabs instellingen voor tekst-naar-spraak"
   />
 
@@ -25,7 +27,7 @@
         aria-hidden="true"
       />
       <div>
-        <h2 class="font-semibold">AI-instellingen niet beschikbaar</h2>
+        <h2 class="font-semibold">Spraakmodel niet beschikbaar</h2>
         <p class="text-sm">
           {#if data.loadError.status}
             HTTP {data.loadError.status}: {data.loadError.message}
@@ -46,9 +48,25 @@
         Opnieuw laden
       </button>
     </div>
-  {:else if data.settings}
+  {:else if !auth.canEditTtsSettings}
+    <div
+      class="alert alert-info"
+      role="status"
+    >
+      <Info
+        aria-hidden="true"
+        class="h-5 w-5"
+      />
+      <span>Alleen-lezen weergave — alleen admins kunnen het Spraakmodel wijzigen.</span>
+    </div>
+  {/if}
+
+  {#if !data.loadError && data.settings}
     {#key JSON.stringify(data.settings)}
-      <TTSSettingsForm settings={data.settings} />
+      <TTSSettingsForm
+        settings={data.settings}
+        canEdit={auth.canEditTtsSettings}
+      />
     {/key}
   {/if}
 </div>

--- a/src/routes/settings/ai/+page.ts
+++ b/src/routes/settings/ai/+page.ts
@@ -24,7 +24,7 @@ function toSettingsLoadError(err: unknown): SettingsLoadError {
     return { message: err.message }
   }
 
-  return { message: 'AI-instellingen laden mislukt' }
+  return { message: 'Spraakmodel laden mislukt' }
 }
 
 export const load: PageLoad = async ({ fetch }) => {

--- a/src/routes/settings/ai/TTSSettingsForm.svelte
+++ b/src/routes/settings/ai/TTSSettingsForm.svelte
@@ -21,11 +21,12 @@
 
   interface Props {
     settings: TTSSettings
+    canEdit: boolean
   }
 
   type ValidationErrorDetails = components['schemas']['ValidationError']
 
-  let { settings }: Props = $props()
+  let { settings, canEdit }: Props = $props()
 
   const numericSettings: {
     field: NumericSettingField
@@ -54,6 +55,7 @@
   const isDirty = $derived(JSON.stringify(form) !== JSON.stringify(savedForm))
   const isV3Model = $derived(form.model === 'eleven_v3')
   const reloadLabel = $derived(isDirty ? 'Wijzigingen verwerpen' : 'Herladen')
+  const formDisabled = $derived(submitting || !canEdit)
 
   function isValidationErrorDetails(value: unknown): value is ValidationErrorDetails {
     return typeof value === 'object' && value !== null && 'errors' in value
@@ -84,7 +86,7 @@
   async function handleSubmit(e: Event): Promise<void> {
     e.preventDefault()
 
-    if (submitting) return
+    if (submitting || !canEdit) return
 
     const result = validateForm(ttsSettingsSchema, form)
     if (!result.success) {
@@ -111,7 +113,7 @@
         return
       }
 
-      toast.success('AI-instellingen opgeslagen')
+      toast.success('Spraakmodel opgeslagen')
       await invalidateAll()
     } finally {
       submitting = false
@@ -168,7 +170,7 @@
         bind:value={form.model}
         options={ttsModelOptions}
         error={errors.model}
-        disabled={submitting}
+        disabled={formDisabled}
       />
 
       <SelectInput
@@ -177,7 +179,7 @@
         bind:value={form.apply_text_normalization}
         options={textNormalizationOptions}
         error={errors.apply_text_normalization}
-        disabled={submitting}
+        disabled={formDisabled}
       />
     </div>
 
@@ -200,7 +202,7 @@
               step={setting.step}
               value={form[setting.field]}
               oninput={e => handleNumberInput(setting.field, e)}
-              disabled={submitting}
+              disabled={formDisabled}
             />
           </div>
           <input
@@ -212,7 +214,7 @@
             step={setting.step}
             value={form[setting.field]}
             oninput={e => handleNumberInput(setting.field, e)}
-            disabled={submitting}
+            disabled={formDisabled}
             aria-label="{setting.label} slider"
           />
           {#if errors[setting.field]}
@@ -229,7 +231,7 @@
         bind:value={form.seed}
         error={errors.seed}
         placeholder="Leeg voor willekeurig"
-        disabled={submitting}
+        disabled={formDisabled}
       />
 
       <fieldset class="fieldset">
@@ -244,7 +246,7 @@
           type="checkbox"
           class="toggle toggle-primary"
           bind:checked={form.use_speaker_boost}
-          disabled={submitting}
+          disabled={formDisabled}
         />
       </fieldset>
     </div>
@@ -259,7 +261,7 @@
         : 'Niet beschikbaar voor het huidige model'}
       rows={3}
       placeholder="[nieuwslezer] "
-      disabled={submitting || !isV3Model}
+      disabled={formDisabled || !isV3Model}
     />
 
     <div class="flex justify-end gap-2 pt-2">
@@ -272,18 +274,20 @@
         <RefreshCw class="h-5 w-5" />
         {reloadLabel}
       </button>
-      <button
-        type="submit"
-        class="btn btn-primary"
-        disabled={submitting || !isDirty}
-      >
-        {#if submitting}
-          <span class="loading loading-sm loading-spinner"></span>
-        {:else}
-          <Check class="h-5 w-5" />
-        {/if}
-        Opslaan
-      </button>
+      {#if canEdit}
+        <button
+          type="submit"
+          class="btn btn-primary"
+          disabled={submitting || !isDirty}
+        >
+          {#if submitting}
+            <span class="loading loading-sm loading-spinner"></span>
+          {:else}
+            <Check class="h-5 w-5" />
+          {/if}
+          Opslaan
+        </button>
+      {/if}
     </div>
   </div>
 </form>


### PR DESCRIPTION
## Summary

- Move `/settings/ai` from the **Admin** sidebar section to the **AI** section
- Rename the menu label from *AI-instellingen* to **Spraakmodel** (model + voice parameters; avoids confusion with `/voices` "Stemmen" which are voice personas)
- Mirror the API's access model: any authenticated user can read, only admins can write. Non-admins now see the page read-only with an info banner; Save button hidden, inputs disabled, Reload still available.

## Changes

- `auth.svelte.ts` — adds `canViewTtsSettings` (`!!user`) and `canEditTtsSettings` (`isAdmin`) derived's, parallel to the existing `canView/canEditPronunciations`
- `Layout.svelte` — `/settings/ai` moved into `aiNavItems`; section gate widened to `canViewPronunciations || canViewTtsSettings`
- `settings/ai/+page.svelte` — PageHeader title, loadError h2, and read-only banner added; `canEdit` prop forwarded
- `settings/ai/+page.ts` — fallback string renamed
- `TTSSettingsForm.svelte` — new `canEdit` prop + `formDisabled` derived, all editable inputs disabled in read-only mode, Save hidden via `{#if canEdit}`, `handleSubmit` guard, toast text updated

## Test plan

- [ ] Admin: sees 'Spraakmodel' in the AI section, can edit fields and save
- [ ] Editor: sees 'Spraakmodel' in the AI section, sees read-only banner, all inputs disabled, no Save button, Reload works
- [ ] Viewer: same as editor
- [ ] Logged out: AI section is hidden (sidebar gate)
- [ ] Admin section now shows only 'Gebruikers'
- [ ] Existing bookmark to `/settings/ai` still works (route unchanged)