### PR TITLE
refactor(ui): use native daisyUI fieldset-label and alert modifiers

### DIFF
--- a/src/lib/components/ui/FormField.svelte
+++ b/src/lib/components/ui/FormField.svelte
@@ -21,9 +21,9 @@
   </label>
   {@render children()}
   {#if error}
-    <p class="label max-w-full whitespace-normal text-sm leading-relaxed text-error">{error}</p>
+    <p class="fieldset-label text-sm leading-relaxed text-error">{error}</p>
   {:else if hint}
-    <p class="label max-w-full whitespace-normal text-sm leading-relaxed text-base-content/70">
+    <p class="fieldset-label text-sm leading-relaxed text-base-content/70">
       {hint}
     </p>
   {/if}

--- a/src/lib/components/ui/WeekdayCheckboxGroup.svelte
+++ b/src/lib/components/ui/WeekdayCheckboxGroup.svelte
@@ -15,7 +15,7 @@
   <legend class="fieldset-legend">{label}</legend>
   <div class="flex flex-wrap gap-2">
     {#each Object.entries(weekdayLabels) as [key, dayLabel] (key)}
-      <label class="label cursor-pointer gap-2">
+      <label class="fieldset-label cursor-pointer gap-2">
         <input
           type="checkbox"
           bind:checked={value[key as keyof Weekdays]}

--- a/src/routes/pronunciations/PronunciationRulesForm.svelte
+++ b/src/routes/pronunciations/PronunciationRulesForm.svelte
@@ -473,9 +473,7 @@
                       disabled={!editable}
                     />
                     {#if errs?.string_to_replace}
-                      <p
-                        class="label max-w-full whitespace-normal text-sm leading-relaxed text-error"
-                      >
+                      <p class="fieldset-label text-sm leading-relaxed text-error">
                         {errs.string_to_replace}
                       </p>
                     {/if}
@@ -492,9 +490,7 @@
                       disabled={!editable}
                     />
                     {#if errs?.ipa}
-                      <p
-                        class="label max-w-full whitespace-normal text-sm leading-relaxed text-error"
-                      >
+                      <p class="fieldset-label text-sm leading-relaxed text-error">
                         {errs.ipa}
                       </p>
                     {/if}
@@ -565,13 +561,11 @@
                   disabled={!editable}
                 />
                 {#if errs?.string_to_replace}
-                  <p class="label max-w-full whitespace-normal text-sm leading-relaxed text-error">
+                  <p class="fieldset-label text-sm leading-relaxed text-error">
                     {errs.string_to_replace}
                   </p>
                 {:else}
-                  <p
-                    class="label max-w-full whitespace-normal text-sm leading-relaxed text-base-content/70"
-                  >
+                  <p class="fieldset-label text-sm leading-relaxed text-base-content/70">
                     Exacte tekst die in de story voorkomt.
                   </p>
                 {/if}
@@ -595,13 +589,11 @@
                   disabled={!editable}
                 />
                 {#if errs?.ipa}
-                  <p class="label max-w-full whitespace-normal text-sm leading-relaxed text-error">
+                  <p class="fieldset-label text-sm leading-relaxed text-error">
                     {errs.ipa}
                   </p>
                 {:else}
-                  <p
-                    class="label max-w-full whitespace-normal text-sm leading-relaxed text-base-content/70"
-                  >
+                  <p class="fieldset-label text-sm leading-relaxed text-base-content/70">
                     {inlineIpaHint}
                   </p>
                 {/if}

--- a/src/routes/speech-generation/+page.svelte
+++ b/src/routes/speech-generation/+page.svelte
@@ -21,9 +21,12 @@
   />
 
   {#if data.loadError}
-    <div class="alert border-warning/30 bg-warning/10 text-base-content">
+    <div
+      class="alert alert-warning"
+      role="alert"
+    >
       <TriangleAlert
-        class="h-5 w-5 text-warning"
+        class="h-5 w-5"
         aria-hidden="true"
       />
       <div>

--- a/src/routes/speech-generation/TTSSettingsForm.svelte
+++ b/src/routes/speech-generation/TTSSettingsForm.svelte
@@ -252,13 +252,11 @@
             aria-label="{setting.label} slider"
           />
           {#if errors[setting.field]}
-            <p class="label max-w-full whitespace-normal text-sm leading-relaxed text-error">
+            <p class="fieldset-label text-sm leading-relaxed text-error">
               {errors[setting.field]}
             </p>
           {:else}
-            <p
-              class="label max-w-full whitespace-normal text-sm leading-relaxed text-base-content/70"
-            >
+            <p class="fieldset-label text-sm leading-relaxed text-base-content/70">
               {setting.hint}
             </p>
           {/if}


### PR DESCRIPTION
## Summary

Follow-up to the search-input fix. A full repo scan (every shared component + every route) confirmed the app is already very idiomatic daisyUI 5 — native `drawer`/`navbar`/`menu`/`avatar`, `<dialog class=\"modal\">`, `toast`+`alert`, `tooltip`, `join`, `loading`, `card`/`table`/`btn`/`badge`, and native form controls throughout. This PR cleans up the two genuine non-native usages that remained.

## Changes

**1. `.label` → `.fieldset-label` for helper/error text**
daisyUI 5's `.label` is meant for affixes *inside* an `.input`/`.select` group and is `white-space: nowrap` with a capped width. It was being used for standalone hint/error `<p>`s under fieldsets, then immediately overridden with `max-w-full whitespace-normal` to undo the nowrap (the same nowrap that previously caused mobile overflow). daisyUI provides `.fieldset-label` for exactly this — flex, no nowrap, no width cap — so the workaround utilities are dropped.

Touched: `FormField.svelte` (app-wide, all forms), `TTSSettingsForm.svelte`, `PronunciationRulesForm.svelte`, and the checkbox label in `WeekdayCheckboxGroup.svelte`.

**2. Hand-tinted warning alert → native `alert-warning`**
`speech-generation/+page.svelte` rendered its load-error with manual colors (`alert border-warning/30 bg-warning/10 text-base-content`) and no `role`. Its sibling `pronunciations/+page.svelte` already uses the native `alert alert-warning` + `role=\"alert\"`. Aligned the two and removed the now-redundant `text-warning` on the icon (it would be near-invisible on the solid warning background).

## Out of scope (deliberately)

`ReadMode.svelte` is a bespoke full-screen reading/teleprompter experience (custom gradients, drop-cap, scroll-progress, wake-lock, keyboard scrolling). It's a `role=\"dialog\"`/`aria-modal` surface but intentionally **not** a daisyUI `modal`, and converting it would be wrong. Noted here for completeness.

## Verification

- `npm run check` — 0 errors / 0 warnings
- `npm run lint` — clean
- `npm run format:check` — clean
- Rendered the `fieldset-label` helper/error text and the `alert-warning` in headless Chrome (dark theme): hint/error wrap correctly with no overflow; the warning alert is solid amber with readable text and a visible icon.

Note: standalone `npm run check` requires `PUBLIC_API_URL=''` locally (pre-existing env-export issue in `client.ts`/`auth.ts`, unrelated to these changes; CI sets it).